### PR TITLE
Add --prompt/-p option to generate CLI command for LLM context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/llm-integration.yml
+++ b/.github/workflows/llm-integration.yml
@@ -1,0 +1,24 @@
+name: LLM Integration Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  llm-tests:
+    name: LLM Integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run LLM integration tests
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: uv run pytest -m llm -v --no-header

--- a/.github/workflows/llm-integration.yml
+++ b/.github/workflows/llm-integration.yml
@@ -21,4 +21,6 @@ jobs:
       - name: Run LLM integration tests
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          FOUNDRY_API_KEY: ${{ secrets.FOUNDRY_API_KEY }}
+          FOUNDRY_RESOURCE: ${{ secrets.FOUNDRY_RESOURCE }}
         run: uv run pytest -m llm -v --no-header

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,10 @@ packages = ["src/schemashift"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=schemashift --cov-report=term-missing"
+addopts = "--cov=schemashift --cov-report=term-missing -m 'not llm'"
+markers = [
+    "llm: tests that call a real LLM API (require ANTHROPIC_API_KEY)",
+]
 
 [tool.ruff]
 src = ["src"]

--- a/src/schemashift/cli.py
+++ b/src/schemashift/cli.py
@@ -153,7 +153,7 @@ def generate(  # noqa: PLR0913
             llm=llm,
             format_name=name,
             n_sample_rows=rows,
-            prompt=prompt,
+            user_prompt=prompt,
         )
 
         if interactive:

--- a/src/schemashift/cli.py
+++ b/src/schemashift/cli.py
@@ -116,6 +116,12 @@ def dry_run(config_path: Path, sample: str, rows: int) -> None:
     default=False,
     help="Interactively review generated config before saving.",
 )
+@click.option(
+    "--prompt",
+    "-p",
+    default=None,
+    help="Additional context for the LLM (e.g. column units, timestamp formats).",
+)
 def generate(  # noqa: PLR0913
     file: str,
     target_schema: str | None,
@@ -124,6 +130,7 @@ def generate(  # noqa: PLR0913
     name: str | None,
     rows: int,
     interactive: bool,
+    prompt: str | None,
 ) -> None:
     """Generate a FormatConfig for an unknown file using an LLM.
 
@@ -146,6 +153,7 @@ def generate(  # noqa: PLR0913
             llm=llm,
             format_name=name,
             n_sample_rows=rows,
+            prompt=prompt,
         )
 
         if interactive:

--- a/src/schemashift/llm.py
+++ b/src/schemashift/llm.py
@@ -184,9 +184,7 @@ def generate_config(
 
     df: pl.DataFrame = read_file(path).head(n_sample_rows).collect()  # ty: ignore[invalid-assignment]
     inferred_name = format_name if format_name is not None else Path(path).stem
-    built_prompt = build_prompt(
-        df, target_schema, list(df.columns), example_configs, inferred_name, prompt=prompt
-    )
+    built_prompt = build_prompt(df, target_schema, list(df.columns), example_configs, inferred_name, prompt=prompt)
 
     # Side-channels: the tool captures its result and all attempt records here.
     result_box: list[FormatConfig] = []

--- a/src/schemashift/llm.py
+++ b/src/schemashift/llm.py
@@ -84,6 +84,8 @@ def build_prompt(
         file_columns: Column names present in the source file.
         example_configs: Optional list of existing FormatConfigs to show as examples.
         format_name: Suggested name for the new format config.
+        prompt: Optional extra context appended to the prompt (e.g. unit
+            conventions, timestamp formats).
 
     Returns:
         A prompt string ready to send to an LLM.
@@ -163,6 +165,8 @@ def generate_config(
         format_name: Name for the generated config. Defaults to the file stem.
         max_retries: Number of additional attempts after the first failure.
         n_sample_rows: Number of rows to sample from the file for the prompt.
+        prompt: Optional extra context for the LLM (e.g. unit conventions,
+            timestamp formats).
 
     Returns:
         A validated :class:`~schemashift.models.FormatConfig`.

--- a/src/schemashift/llm.py
+++ b/src/schemashift/llm.py
@@ -74,7 +74,7 @@ def build_prompt(
     file_columns: list[str],
     example_configs: list[FormatConfig] | None = None,
     format_name: str = "unknown_format",
-    prompt: str | None = None,
+    user_prompt: str | None = None,
 ) -> str:
     """Build a prompt requesting a FormatConfig for the given file.
 
@@ -84,7 +84,7 @@ def build_prompt(
         file_columns: Column names present in the source file.
         example_configs: Optional list of existing FormatConfigs to show as examples.
         format_name: Suggested name for the new format config.
-        prompt: Optional extra context appended to the prompt (e.g. unit
+        user_prompt: Optional extra context appended to the prompt (e.g. unit
             conventions, timestamp formats).
 
     Returns:
@@ -134,8 +134,8 @@ def build_prompt(
             parts.append(ex.model_dump_json(indent=2))
 
     # Additional user-provided context
-    if prompt:
-        parts.append(f"\n## Additional Context\n{prompt}")
+    if user_prompt:
+        parts.append(f"\n## Additional Context\n{user_prompt}")
 
     return "\n".join(parts)
 
@@ -148,7 +148,7 @@ def generate_config(
     format_name: str | None = None,
     max_retries: int = 2,
     n_sample_rows: int = 15,
-    prompt: str | None = None,
+    user_prompt: str | None = None,
 ) -> FormatConfig:
     """Generate a FormatConfig for the given file using the LangChain agent API.
 
@@ -165,7 +165,7 @@ def generate_config(
         format_name: Name for the generated config. Defaults to the file stem.
         max_retries: Number of additional attempts after the first failure.
         n_sample_rows: Number of rows to sample from the file for the prompt.
-        prompt: Optional extra context for the LLM (e.g. unit conventions,
+        user_prompt: Optional extra context for the LLM (e.g. unit conventions,
             timestamp formats).
 
     Returns:
@@ -184,7 +184,7 @@ def generate_config(
 
     df: pl.DataFrame = read_file(path).head(n_sample_rows).collect()  # ty: ignore[invalid-assignment]
     inferred_name = format_name if format_name is not None else Path(path).stem
-    built_prompt = build_prompt(df, target_schema, list(df.columns), example_configs, inferred_name, prompt=prompt)
+    prompt = build_prompt(df, target_schema, list(df.columns), example_configs, inferred_name, user_prompt=user_prompt)
 
     # Side-channels: the tool captures its result and all attempt records here.
     result_box: list[FormatConfig] = []
@@ -245,7 +245,7 @@ def generate_config(
     agent = create_agent(llm, [submit_format_config])
     try:
         agent.invoke(
-            {"messages": [HumanMessage(content=built_prompt)]},
+            {"messages": [HumanMessage(content=prompt)]},
             config={"recursion_limit": recursion_limit},
         )
     except Exception as exc:

--- a/src/schemashift/llm.py
+++ b/src/schemashift/llm.py
@@ -74,6 +74,7 @@ def build_prompt(
     file_columns: list[str],
     example_configs: list[FormatConfig] | None = None,
     format_name: str = "unknown_format",
+    prompt: str | None = None,
 ) -> str:
     """Build a prompt requesting a FormatConfig for the given file.
 
@@ -130,6 +131,10 @@ def build_prompt(
         for ex in example_configs:
             parts.append(ex.model_dump_json(indent=2))
 
+    # Additional user-provided context
+    if prompt:
+        parts.append(f"\n## Additional Context\n{prompt}")
+
     return "\n".join(parts)
 
 
@@ -141,6 +146,7 @@ def generate_config(
     format_name: str | None = None,
     max_retries: int = 2,
     n_sample_rows: int = 15,
+    prompt: str | None = None,
 ) -> FormatConfig:
     """Generate a FormatConfig for the given file using the LangChain agent API.
 
@@ -174,7 +180,9 @@ def generate_config(
 
     df: pl.DataFrame = read_file(path).head(n_sample_rows).collect()  # ty: ignore[invalid-assignment]
     inferred_name = format_name if format_name is not None else Path(path).stem
-    prompt = build_prompt(df, target_schema, list(df.columns), example_configs, inferred_name)
+    built_prompt = build_prompt(
+        df, target_schema, list(df.columns), example_configs, inferred_name, prompt=prompt
+    )
 
     # Side-channels: the tool captures its result and all attempt records here.
     result_box: list[FormatConfig] = []
@@ -235,7 +243,7 @@ def generate_config(
     agent = create_agent(llm, [submit_format_config])
     try:
         agent.invoke(
-            {"messages": [HumanMessage(content=prompt)]},
+            {"messages": [HumanMessage(content=built_prompt)]},
             config={"recursion_limit": recursion_limit},
         )
     except Exception as exc:

--- a/src/schemashift/transform.py
+++ b/src/schemashift/transform.py
@@ -146,6 +146,7 @@ def smart_transform(
     example_configs: list[FormatConfig] | None = None,
     max_retries: int = 2,
     n_sample_rows: int = 15,
+    prompt: str | None = None,
 ) -> pl.LazyFrame:
     """Full detect-or-generate flow.
 
@@ -165,6 +166,7 @@ def smart_transform(
         example_configs: Example configs for LLM prompt.
         max_retries: Max LLM retries.
         n_sample_rows: Rows to sample for LLM.
+        prompt: Additional context for the LLM (e.g. unit conventions).
 
     Returns:
         Transformed pl.LazyFrame.
@@ -204,6 +206,7 @@ def smart_transform(
         example_configs=example_configs,
         max_retries=max_retries,
         n_sample_rows=n_sample_rows,
+        prompt=prompt,
     )
 
     # Review callback

--- a/src/schemashift/transform.py
+++ b/src/schemashift/transform.py
@@ -146,7 +146,7 @@ def smart_transform(
     example_configs: list[FormatConfig] | None = None,
     max_retries: int = 2,
     n_sample_rows: int = 15,
-    prompt: str | None = None,
+    user_prompt: str | None = None,
 ) -> pl.LazyFrame:
     """Full detect-or-generate flow.
 
@@ -166,7 +166,7 @@ def smart_transform(
         example_configs: Example configs for LLM prompt.
         max_retries: Max LLM retries.
         n_sample_rows: Rows to sample for LLM.
-        prompt: Additional context for the LLM (e.g. unit conventions).
+        user_prompt: Additional context for the LLM (e.g. unit conventions).
 
     Returns:
         Transformed pl.LazyFrame.
@@ -206,7 +206,7 @@ def smart_transform(
         example_configs=example_configs,
         max_retries=max_retries,
         n_sample_rows=n_sample_rows,
-        prompt=prompt,
+        user_prompt=user_prompt,
     )
 
     # Review callback

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared pytest configuration and fixtures."""
+
+import os
+
+import pytest
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip ``@pytest.mark.llm`` tests when no LLM API key is available."""
+    if config.option.markexpr and "llm" in config.option.markexpr:
+        # User explicitly requested llm tests — only skip if key is missing.
+        has_key = bool(os.getenv("ANTHROPIC_API_KEY") or os.getenv("FOUNDRY_API_KEY"))
+        if not has_key:
+            skip = pytest.mark.skip(reason="No ANTHROPIC_API_KEY or FOUNDRY_API_KEY set")
+            for item in items:
+                if item.get_closest_marker("llm"):
+                    item.add_marker(skip)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -77,6 +77,17 @@ class TestBuildPrompt:
         prompt = build_prompt(df, schema, ["x"])
         assert "submit_format_config" in prompt
 
+    def test_custom_prompt_appended(self, schema):
+        df = pl.DataFrame({"x": [1]})
+        result = build_prompt(df, schema, ["x"], prompt="volume is in lots not wafers")
+        assert "Additional Context" in result
+        assert "volume is in lots not wafers" in result
+
+    def test_no_additional_context_when_prompt_none(self, schema):
+        df = pl.DataFrame({"x": [1]})
+        result = build_prompt(df, schema, ["x"], prompt=None)
+        assert "Additional Context" not in result
+
 
 class TestGenerateConfig:
     @pytest.fixture

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -79,13 +79,13 @@ class TestBuildPrompt:
 
     def test_custom_prompt_appended(self, schema):
         df = pl.DataFrame({"x": [1]})
-        result = build_prompt(df, schema, ["x"], prompt="volume is in lots not wafers")
+        result = build_prompt(df, schema, ["x"], user_prompt="volume is in lots not wafers")
         assert "Additional Context" in result
         assert "volume is in lots not wafers" in result
 
     def test_no_additional_context_when_prompt_none(self, schema):
         df = pl.DataFrame({"x": [1]})
-        result = build_prompt(df, schema, ["x"], prompt=None)
+        result = build_prompt(df, schema, ["x"], user_prompt=None)
         assert "Additional Context" not in result
 
 

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -1,0 +1,113 @@
+"""Integration tests that call a real LLM.
+
+These tests are excluded from the default pytest run via the ``llm`` marker.
+Run explicitly with::
+
+    pytest -m llm
+
+Requires ``ANTHROPIC_API_KEY`` (or ``FOUNDRY_API_KEY`` + ``FOUNDRY_RESOURCE``)
+in the environment.
+"""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from schemashift.cli import cli
+from schemashift.llm import generate_config, load_default_llm
+from schemashift.target_schema import TargetSchema
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+pytestmark = pytest.mark.llm
+
+
+@pytest.fixture(scope="module")
+def llm():
+    return load_default_llm()
+
+
+@pytest.fixture
+def lot_movement_schema():
+    return TargetSchema.from_yaml(FIXTURES / "configs" / "lot_movement_schema.yaml")
+
+
+@pytest.fixture
+def camstar_csv():
+    return str(FIXTURES / "csv" / "camstar_sample.csv")
+
+
+class TestGenerateConfigIntegration:
+    """End-to-end generation with a real LLM."""
+
+    def test_generates_valid_config(self, camstar_csv, lot_movement_schema, llm):
+        config = generate_config(
+            path=camstar_csv,
+            target_schema=lot_movement_schema,
+            llm=llm,
+            n_sample_rows=5,
+        )
+        assert config.name
+        assert len(config.columns) > 0
+
+        # Config should actually transform the file without error
+        from schemashift.transform import dry_run
+
+        df = dry_run(config, camstar_csv, n_rows=3)
+        assert len(df) == 3
+
+    def test_prompt_influences_output(self, camstar_csv, lot_movement_schema, llm):
+        """The prompt arg should be included as context for the LLM."""
+        config = generate_config(
+            path=camstar_csv,
+            target_schema=lot_movement_schema,
+            llm=llm,
+            n_sample_rows=5,
+            prompt=(
+                "The QTY column represents wafer count per lot. "
+                "HOLD_STATUS of 'NONE' means the lot is NOT on hold (false)."
+            ),
+        )
+        assert config.name
+        assert len(config.columns) > 0
+
+        from schemashift.transform import dry_run
+
+        df = dry_run(config, camstar_csv, n_rows=3)
+        assert len(df) == 3
+
+
+class TestCLIGenerateIntegration:
+    """End-to-end CLI generate with a real LLM."""
+
+    def test_cli_generate(self, camstar_csv, lot_movement_schema, tmp_path):
+        out = tmp_path / "config.json"
+        schema_path = FIXTURES / "configs" / "lot_movement_schema.yaml"
+        result = CliRunner().invoke(
+            cli,
+            ["generate", camstar_csv, "-t", str(schema_path), "-o", str(out), "--rows", "5"],
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+
+    def test_cli_generate_with_prompt(self, camstar_csv, lot_movement_schema, tmp_path):
+        out = tmp_path / "config.json"
+        schema_path = FIXTURES / "configs" / "lot_movement_schema.yaml"
+        result = CliRunner().invoke(
+            cli,
+            [
+                "generate",
+                camstar_csv,
+                "-t",
+                str(schema_path),
+                "-o",
+                str(out),
+                "--rows",
+                "5",
+                "--prompt",
+                "QTY is wafer count. HOLD_STATUS 'NONE' means not on hold.",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists()

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -64,7 +64,7 @@ class TestGenerateConfigIntegration:
             target_schema=lot_movement_schema,
             llm=llm,
             n_sample_rows=5,
-            prompt=(
+            user_prompt=(
                 "The QTY column represents wafer count per lot. "
                 "HOLD_STATUS of 'NONE' means the lot is NOT on hold (false)."
             ),

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",


### PR DESCRIPTION
Threads an optional `prompt` parameter through the generate CLI command, `generate_config()`, `build_prompt()`, and `smart_transform()` so users can provide additional context to the LLM (e.g. unit conventions, timestamp formats) during config generation.