### PR TITLE
Architecture improvements: orchestration, detection, DSL, and LLMBackend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# AGENTS.md
+
+Instructions for coding agents working in this repository.
+
+## Preferred tools
+
+- Use `rg` for fast text and file search instead of slower defaults like `grep` or `find` when available.
+- Use `rtk` when reading large files, listing directories, summarising command output, or running noisy commands that would otherwise waste context.
+- Good defaults in this repo:
+  - `rg "pattern" src tests`
+  - `rg --files src tests docs`
+  - `rtk read README.md`
+  - `rtk tree src`
+  - `rtk pytest`
+  - `rtk ruff check src tests`
+
+## Commands
+
+```bash
+rtk uv run pytest                              # all tests with coverage
+rtk uv run pytest tests/test_dsl_parser.py -v  # single file
+rtk uv run pytest -k "test_name"               # single test by name
+rtk uv run ruff check src/                     # lint
+rtk uv run black src/ tests/            # formatting check
+pre-commit run                                 # lint + format (run after staging changes)
+```
+
+## Architecture
+
+`schemashift` transforms tabular files into a canonical schema using declarative JSON/YAML configs.
+
+Pipeline:
+
+```text
+File → Reader → LazyFrame → Transform Engine → LazyFrame
+                    ↑
+              Registry / Detector
+                    ↑ (miss)
+              LLM Generator
+```
+
+## Important concepts
+
+### Config model
+
+`FormatConfig` is the central object. Each `ColumnMapping` must define exactly one of:
+
+- `source` — rename a column
+- `expr` — DSL expression string compiled at transform time
+- `constant` — literal value broadcast to all rows
+
+`FormatConfig.source_columns()` extracts referenced source columns for format detection.
+
+### DSL
+
+The DSL is a closed language: string → AST → `polars.Expr`.
+
+- `parser.py` is a hand-written recursive descent parser with explicit allowlists.
+- `ast_nodes.py` defines frozen AST dataclasses.
+- `compiler.py` lowers AST nodes into native Polars expressions.
+
+When adding a DSL operation:
+
+1. Add it to the allowlist in `parser.py`
+2. Add compilation support in `compiler.py`
+3. Add it to `_DSL_REFERENCE` in `llm.py`
+
+Never use `eval()` or introduce arbitrary method dispatch.
+
+### Transform engine
+
+- `transform(path, config)` returns a `pl.LazyFrame`
+- Avoid materialising data unless `dry_run()` is required or the caller explicitly collects
+- `smart_transform()` handles detect-or-generate flow and optional review / auto-registration
+
+### Registry
+
+- `DictRegistry` is in-memory
+- `FileSystemRegistry` stores one JSON file per config
+- `FileSystemRegistry.load_schema()` looks for target schemas in a `schemas/` subdirectory
+
+### LLM generation
+
+`generate_config()` accepts a LangChain `BaseChatModel`, validates generated JSON, validates DSL syntax, and dry-runs before success.
+
+### Target schema
+
+`TargetSchema` is the source of truth for output shape:
+
+- `validate_lazy()` checks names and dtypes without collecting
+- `validate_eager()` additionally checks nulls in required columns
+
+## Key constraints
+
+- Keep format-specific logic in `readers.py`; the transform engine should only work with `pl.LazyFrame`
+- Config validation and output-schema validation are different concerns
+- Excel uses `fastexcel` / calamine semantics; integer sheet references map to `sheet_id` (1-based)
+- Unix timestamp to Polars `Datetime` requires microseconds (`1_000_000` multiplier), not nanoseconds
+
+## Errors
+
+All project-specific errors inherit from `SchemaShiftError`.
+
+Important ones:
+
+- `DSLSyntaxError`
+- `DSLRuntimeError`
+- `AmbiguousFormatError`
+- `LLMGenerationError`
+
+For deeper project-specific guidance, see `CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,27 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Preferred tools
+
+- Use `rg` for fast text and file search instead of slower defaults like `grep` or `find` when available.
+- Use `rtk` when reading large files, listing directories, summarising command output, or running noisy commands that would otherwise waste context.
+- Good defaults in this repo:
+  - `rg "pattern" src tests`
+  - `rg --files src tests docs`
+  - `rtk read README.md`
+  - `rtk tree src`
+  - `rtk pytest`
+  - `rtk ruff check src tests`
+
 ## Commands
 
 ```bash
-uv run pytest                        # all tests with coverage
-uv run pytest tests/test_dsl_parser.py -v   # single file
-uv run pytest -k "test_name"         # single test by name
-uv run ruff check src/               # lint
-pre-commit run                       # lint + format (run after staging changes)
+rtk uv run pytest                              # all tests with coverage
+rtk uv run pytest tests/test_dsl_parser.py -v  # single file
+rtk uv run pytest -k "test_name"               # single test by name
+rtk uv run ruff check src/                     # lint
+rtk uv run black src/ tests/             # formatting check
+pre-commit run                                 # lint + format (run after staging changes)
 ```
 
 ## Architecture

--- a/src/schemashift/__init__.py
+++ b/src/schemashift/__init__.py
@@ -16,17 +16,12 @@ from schemashift.errors import (
 )
 from schemashift.llm import load_default_llm
 from schemashift.models import ColumnMapping, FormatConfig, ReaderConfig
+from schemashift.orchestration import auto_transform, smart_transform
 from schemashift.readers import read_file
 from schemashift.registry import DictRegistry, FileSystemRegistry, Registry
 from schemashift.schema import get_schema, get_schema_path
 from schemashift.target_schema import TargetSchema
-from schemashift.transform import (
-    auto_transform,
-    dry_run,
-    smart_transform,
-    transform,
-    validate_config,
-)
+from schemashift.transform import dry_run, transform, validate_config
 
 __all__ = [
     "get_schema",

--- a/src/schemashift/__init__.py
+++ b/src/schemashift/__init__.py
@@ -9,6 +9,7 @@ from schemashift.errors import (
     FormatDetectionError,
     LLMGenerationError,
     ReaderError,
+    ReviewRejectedError,
     SchemaShiftError,
     SchemaValidationError,
     UnsupportedFileError,
@@ -54,5 +55,6 @@ __all__ = [
     "UnsupportedFileError",
     "LLMGenerationError",
     "ReaderError",
+    "ReviewRejectedError",
     "load_default_llm",
 ]

--- a/src/schemashift/cli.py
+++ b/src/schemashift/cli.py
@@ -15,6 +15,7 @@ from schemashift.errors import (
     AmbiguousFormatError,
     ConfigValidationError,
     FormatDetectionError,
+    ReviewRejectedError,
 )
 from schemashift.models import FormatConfig
 from schemashift.registry import FileSystemRegistry
@@ -55,7 +56,7 @@ def transform(file: str, config: Path | None, registry: str | None, output: str 
         else:
             click.echo(str(df.head(20)))
 
-    except (FormatDetectionError, AmbiguousFormatError, ConfigValidationError) as exc:
+    except (FormatDetectionError, AmbiguousFormatError, ConfigValidationError, ReviewRejectedError) as exc:
         click.echo(f"Error: {exc}", err=True)
         sys.exit(1)
     except Exception as exc:

--- a/src/schemashift/cli.py
+++ b/src/schemashift/cli.py
@@ -68,7 +68,7 @@ def validate(config_path: Path) -> None:
     """Validate a format config file."""
     try:
         fmt_config = _load_format_config(config_path)
-    except (ConfigValidationError, Exception) as exc:
+    except Exception as exc:
         click.echo(f"Config load error: {exc}", err=True)
         sys.exit(1)
 
@@ -133,8 +133,8 @@ def generate(  # noqa: PLR0913
 ) -> None:
     """Generate a FormatConfig for an unknown file using an LLM.
 
-    Requires ANTHROPIC_API_KEY or OPENAI_API_KEY in environment,
-    or configure your LLM via environment variables.
+    Requires ANTHROPIC_API_KEY (direct) or FOUNDRY_API_KEY + FOUNDRY_RESOURCE
+    (Azure AI Foundry) to be set in the environment.
     """
     try:
         from schemashift.llm import generate_config

--- a/src/schemashift/cli.py
+++ b/src/schemashift/cli.py
@@ -48,13 +48,11 @@ def transform(file: str, config: Path | None, registry: str | None, output: str 
         else:
             raise click.UsageError("Provide either --config or --registry.")
 
-        df: pl.DataFrame = lf.collect()  # ty: ignore[invalid-assignment]
-
         if output is not None:
-            _write_output(df, output)
-            click.echo(f"Written {len(df)} rows to '{output}'.")
+            _sink_output(lf, output)
+            click.echo(f"Written to '{output}'.")
         else:
-            click.echo(str(df.head(20)))
+            click.echo(str(lf.head(20).collect()))
 
     except (FormatDetectionError, AmbiguousFormatError, ConfigValidationError, ReviewRejectedError) as exc:
         click.echo(f"Error: {exc}", err=True)
@@ -268,15 +266,15 @@ def _load_format_config(path: Path) -> FormatConfig:
     return FormatConfig.model_validate(data)
 
 
-def _write_output(df: pl.DataFrame, output: str) -> None:
-    """Write a DataFrame to the given path based on its file extension."""
+def _sink_output(lf: pl.LazyFrame, output: str) -> None:
+    """Stream a LazyFrame to a file using Polars sink methods where available."""
     out_path = Path(output)
     ext = out_path.suffix.lower()
     if ext == ".csv":
-        df.write_csv(output)
+        lf.sink_csv(out_path)
     elif ext == ".parquet":
-        df.write_parquet(output)
+        lf.sink_parquet(out_path)
     elif ext == ".json":
-        df.write_json(output)
+        lf.collect().write_json(out_path)
     else:
         raise click.UsageError(f"Unsupported output format '{ext}'. Use .csv, .parquet, or .json.")

--- a/src/schemashift/cli.py
+++ b/src/schemashift/cli.py
@@ -18,10 +18,11 @@ from schemashift.errors import (
     ReviewRejectedError,
 )
 from schemashift.models import FormatConfig
+from schemashift.orchestration import auto_transform
 from schemashift.registry import FileSystemRegistry
-from schemashift.transform import auto_transform, validate_config
 from schemashift.transform import dry_run as _dry_run
 from schemashift.transform import transform as _transform
+from schemashift.transform import validate_config
 
 _CONFIG_PATH_TYPE = click.Path(exists=True, file_okay=True, readable=True, path_type=Path)
 

--- a/src/schemashift/cli.py
+++ b/src/schemashift/cli.py
@@ -228,8 +228,7 @@ def _resolve_schema(target_schema_path: str | None, registry_path: str | None) -
 
     Resolution order:
     1. If *target_schema_path* is given, load it directly.
-    2. If *registry_path* is given, glob for ``*.yaml``/``*.yml`` in
-       ``{registry_path}/schemas/``.  Exactly one match is required.
+    2. If *registry_path* is given, delegate to :meth:`FileSystemRegistry.load_schema`.
     3. Otherwise raise :class:`click.UsageError`.
     """
     from schemashift.target_schema import TargetSchema
@@ -238,16 +237,12 @@ def _resolve_schema(target_schema_path: str | None, registry_path: str | None) -
         return TargetSchema.from_yaml(target_schema_path)
 
     if registry_path is not None:
-        schemas_dir = Path(registry_path) / "schemas"
-        if schemas_dir.exists():
-            yamls = list(schemas_dir.glob("*.yaml")) + list(schemas_dir.glob("*.yml"))
-            if len(yamls) == 1:
-                return TargetSchema.from_yaml(yamls[0])
-            elif len(yamls) > 1:
-                names = [y.name for y in yamls]
-                raise click.UsageError(
-                    f"Multiple schemas found in '{schemas_dir}': {names}. Use --target-schema to specify one."
-                )
+        try:
+            schema = FileSystemRegistry(registry_path).load_schema()
+        except ValueError as exc:
+            raise click.UsageError(str(exc)) from exc
+        if schema is not None:
+            return schema
 
     raise click.UsageError("Provide --target-schema or --registry with a schemas/ subdirectory.")
 

--- a/src/schemashift/detection.py
+++ b/src/schemashift/detection.py
@@ -8,15 +8,18 @@ from schemashift.registry import Registry
 def detect_format(
     file_columns: list[str],
     registry: Registry,
+    min_score: float = 0.4,
 ) -> FormatConfig | None:
     """Detect which registered config matches a file's columns.
 
     A config matches when the file's column set is a superset of the config's
     referenced source columns (i.e. every column the config needs is present).
+    Matching configs are ranked by specificity score: ``len(required) / len(file_columns)``.
 
     Args:
         file_columns: Column names found in the file being inspected.
         registry: Registry to search for candidate configs.
+        min_score: Minimum specificity score required for a match.
 
     Returns:
         The matching FormatConfig when exactly one config matches, or None when
@@ -26,7 +29,8 @@ def detect_format(
         AmbiguousFormatError: When two or more configs match.
     """
     column_set = set(file_columns)
-    matches: list[FormatConfig] = []
+    scored_matches: list[tuple[float, FormatConfig]] = []
+    subset_matches: list[FormatConfig] = []
 
     for config in registry.list_configs():
         required = config.source_columns()
@@ -35,11 +39,24 @@ def detect_format(
         # would always cause AmbiguousFormatError when combined with real configs.
         # Such configs must be applied explicitly via --config rather than
         # auto-detected from the registry.
-        if required and required.issubset(column_set):
-            matches.append(config)
+        if not required or not required.issubset(column_set):
+            continue
+        subset_matches.append(config)
+        score = len(required) / len(column_set)
+        if score >= min_score:
+            scored_matches.append((score, config))
 
-    if len(matches) == 0:
+    if not scored_matches:
+        if len(subset_matches) > 1:
+            candidate_names = [c.name for c in subset_matches]
+            raise AmbiguousFormatError(
+                f"Multiple low-specificity configs match the provided columns: {candidate_names}. "
+                "Add more discriminating columns to distinguish them.",
+                candidates=candidate_names,
+            )
         return None
+    best_score = max(score for score, _ in scored_matches)
+    matches = [config for score, config in scored_matches if score == best_score]
     if len(matches) == 1:
         return matches[0]
 

--- a/src/schemashift/detection.py
+++ b/src/schemashift/detection.py
@@ -30,6 +30,11 @@ def detect_format(
 
     for config in registry.list_configs():
         required = config.source_columns()
+        # Configs whose every mapping uses `constant` (no source columns) are
+        # intentionally excluded from detection — they match any file, so they
+        # would always cause AmbiguousFormatError when combined with real configs.
+        # Such configs must be applied explicitly via --config rather than
+        # auto-detected from the registry.
         if required and required.issubset(column_set):
             matches.append(config)
 

--- a/src/schemashift/dsl/__init__.py
+++ b/src/schemashift/dsl/__init__.py
@@ -35,10 +35,11 @@ Expression Reference
 
 import polars as pl
 
+from .analysis import collect_col_refs
 from .compiler import compile_dsl
 from .parser import parse_dsl
 
-__all__ = ["parse_dsl", "compile_dsl", "parse_and_compile"]
+__all__ = ["parse_dsl", "compile_dsl", "parse_and_compile", "collect_col_refs"]
 
 
 def parse_and_compile(expression: str) -> pl.Expr:

--- a/src/schemashift/dsl/analysis.py
+++ b/src/schemashift/dsl/analysis.py
@@ -1,0 +1,53 @@
+"""AST analysis helpers for the schemashift DSL."""
+
+from schemashift.dsl.ast_nodes import (
+    ASTNode,
+    BinaryOp,
+    Coalesce,
+    ColRef,
+    CustomLookup,
+    Literal,
+    Lookup,
+    MethodCall,
+    UnaryOp,
+    WhenChain,
+    WhenClause,
+)
+
+
+def collect_col_refs(node: ASTNode) -> set[str]:
+    """Collect every column name referenced by ``col(...)`` calls in an AST."""
+    refs: set[str] = set()
+    _visit(node, refs)
+    return refs
+
+
+def _visit(node: ASTNode, refs: set[str]) -> None:
+    match node:
+        case ColRef(name=name):
+            refs.add(name)
+        case Literal():
+            return
+        case BinaryOp(left=left, right=right):
+            _visit(left, refs)
+            _visit(right, refs)
+        case UnaryOp(operand=operand):
+            _visit(operand, refs)
+        case MethodCall(obj=obj, args=args):
+            _visit(obj, refs)
+            for arg in args:
+                _visit(arg, refs)
+        case WhenClause(condition=condition, value=value):
+            _visit(condition, refs)
+            _visit(value, refs)
+        case WhenChain(whens=whens, otherwise=otherwise):
+            for when in whens:
+                _visit(when, refs)
+            _visit(otherwise, refs)
+        case Coalesce(exprs=exprs):
+            for expr in exprs:
+                _visit(expr, refs)
+        case Lookup(expr=expr):
+            _visit(expr, refs)
+        case CustomLookup(expr=expr):
+            _visit(expr, refs)

--- a/src/schemashift/dsl/compiler.py
+++ b/src/schemashift/dsl/compiler.py
@@ -299,8 +299,17 @@ def _compile_method(obj: ASTNode, method: str, args: tuple[ASTNode, ...]) -> pl.
             return base.dt.strftime(fmt)
 
         case "dt.timestamp":
-            _expect_arity(method, args, 0)
-            return base.dt.timestamp("ms")
+            if len(args) == 0:
+                return base.dt.timestamp("ms")
+            _expect_arity(method, args, 1)
+            unit = _literal_str(args[0], method)
+            if unit not in ("ms", "us", "ns"):
+                raise DSLSyntaxError(
+                    f"dt.timestamp() unit must be 'ms', 'us', or 'ns', got {unit!r}",
+                    expression="",
+                    position=-1,
+                )
+            return base.dt.timestamp(unit)
 
         case _:
             raise DSLRuntimeError(f"Unsupported method: {method!r}")

--- a/src/schemashift/dsl/parser.py
+++ b/src/schemashift/dsl/parser.py
@@ -209,7 +209,7 @@ def tokenize(expression: str) -> list[Token]:
 # ---------------------------------------------------------------------------
 
 _KEYWORDS: frozenset[str] = frozenset(
-    {"col", "when", "otherwise", "true", "false", "null", "coalesce", "lookup", "custom_lookup"}
+    {"col", "when", "otherwise", "true", "false", "null", "coalesce", "lookup", "custom_lookup", "not"}
 )
 
 
@@ -307,12 +307,16 @@ class _Parser:
             left = BinaryOp(op, left, right)
         return left
 
-    # unary := '-' unary | atom_with_methods
+    # unary := '-' unary | 'not' unary | atom_with_methods
     def _unary(self) -> ASTNode:
         if self._match(TT.MINUS):
             self._advance()
             operand = self._unary()
             return UnaryOp("-", operand)
+        if self._match(TT.IDENT) and str(self._peek().value) == "not":
+            self._advance()
+            operand = self._unary()
+            return UnaryOp("!", operand)
         return self._atom_with_methods()
 
     # atom_with_methods := atom ('.' method_chain)*
@@ -391,6 +395,12 @@ class _Parser:
                 return self._lookup_expr()
             if ident == "custom_lookup":
                 return self._custom_lookup_expr()
+            if ident == "not":
+                raise DSLSyntaxError(
+                    "'not' must prefix an expression (e.g. not col(\"x\").is_null())",
+                    expression=self._expr,
+                    position=tok.pos,
+                )
             # Unknown identifier
             raise DSLSyntaxError(
                 f"Unknown identifier {ident!r}",

--- a/src/schemashift/errors.py
+++ b/src/schemashift/errors.py
@@ -31,6 +31,10 @@ class FormatDetectionError(SchemaShiftError):
     """Raised when automatic format detection fails."""
 
 
+class ReviewRejectedError(SchemaShiftError):
+    """Raised when a review_fn callback rejects a generated config by returning None."""
+
+
 class AmbiguousFormatError(FormatDetectionError):
     """Raised when multiple formats match with equal confidence."""
 

--- a/src/schemashift/llm.py
+++ b/src/schemashift/llm.py
@@ -2,13 +2,10 @@
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any, Protocol, runtime_checkable
 
 import polars as pl
 from pydantic import ValidationError
-
-if TYPE_CHECKING:
-    from langchain_core.language_models import BaseChatModel
 
 from . import dsl as _dsl_module
 from .errors import LLMGenerationError
@@ -20,6 +17,98 @@ from .transform import dry_run, validate_config
 _log = logging.getLogger(__name__)
 
 _DSL_REFERENCE = _dsl_module.__doc__ or ""
+
+
+@runtime_checkable
+class LLMBackend(Protocol):
+    """Backend interface for config generation."""
+
+    attempts: list[dict[str, Any]]
+
+    def generate(self, prompt: str, schema: dict[str, Any]) -> dict[str, Any]:
+        """Generate a candidate FormatConfig payload."""
+
+
+class LangChainLLMBackend:
+    """LangChain adapter implementing the ``LLMBackend`` protocol."""
+
+    def __init__(self, model: Any, max_retries: int = 2) -> None:
+        self._model = model
+        self._max_retries = max_retries
+        self.attempts: list[dict[str, Any]] = []
+
+    def generate(self, prompt: str, schema: dict[str, Any]) -> dict[str, Any]:
+        try:
+            from langchain.agents import create_agent
+            from langchain_core.messages import HumanMessage
+            from langchain_core.tools import tool
+        except ImportError as exc:
+            raise ImportError("langchain is not installed. Run: pip install 'schemashift[llm]'") from exc
+
+        inferred_name = str(schema["format_name"])
+        path = str(schema["path"])
+        result_box: list[dict[str, Any]] = []
+
+        @tool
+        def submit_format_config(
+            columns: list[dict],
+            name: str = "",
+            description: str = "",
+            drop_unmapped: bool = True,
+        ) -> str:
+            """Submit the generated FormatConfig mapping source columns to the target schema.
+
+            Each column dict must contain 'target' and exactly one of: 'source' (direct
+            column rename), 'expr' (DSL expression string), or 'constant' (literal value).
+            Optional per-column keys: 'dtype' (cast type), 'fillna' (fill-null value).
+            Returns 'Config accepted.' on success, or an error description to fix and retry.
+            """
+            data: dict[str, Any] = {
+                "name": name or inferred_name,
+                "description": description,
+                "columns": columns,
+                "drop_unmapped": drop_unmapped,
+            }
+
+            try:
+                config = FormatConfig.model_validate(data)
+            except (ValidationError, Exception) as exc:
+                error = str(exc)
+                self.attempts.append({"response": data, "error": error})
+                _log.warning("FormatConfig validation attempt failed: %s", error)
+                return f"Validation error: {error}"
+
+            dsl_errors = validate_config(config)
+            if dsl_errors:
+                error = "\n".join(dsl_errors)
+                self.attempts.append({"response": data, "error": error})
+                _log.warning("FormatConfig validation attempt failed: %s", error)
+                return f"DSL errors:\n{error}"
+
+            try:
+                dry_run(config, path, n_rows=5)
+            except Exception as exc:
+                error = str(exc)
+                self.attempts.append({"response": data, "error": error})
+                _log.warning("FormatConfig validation attempt failed: %s", error)
+                return f"Runtime error during dry run: {error}"
+
+            self.attempts.append({"response": data, "error": None})
+            result_box.append(data)
+            return "Config accepted."
+
+        recursion_limit = (self._max_retries + 1) * 3 + 2
+        agent = create_agent(self._model, [submit_format_config])
+        agent.invoke(
+            {"messages": [HumanMessage(content=prompt)]},
+            config={"recursion_limit": recursion_limit},
+        )
+        if result_box:
+            return result_box[0]
+        raise LLMGenerationError(
+            "Agent completed without submitting a valid config",
+            attempts=self.attempts,
+        )
 
 
 def load_default_llm() -> Any:
@@ -146,7 +235,7 @@ def build_prompt(
 def generate_config(
     path: str,
     target_schema: TargetSchema,
-    llm: "BaseChatModel",
+    llm: "LLMBackend | Any",
     example_configs: list[FormatConfig] | None = None,
     format_name: str | None = None,
     max_retries: int = 2,
@@ -154,17 +243,16 @@ def generate_config(
     user_prompt: str | None = None,
     reader_config: ReaderConfig | None = None,
 ) -> FormatConfig:
-    """Generate a FormatConfig for the given file using the LangChain agent API.
+    """Generate a FormatConfig for the given file using the configured LLM backend.
 
-    Creates an agent via :func:`langchain.agents.create_agent` with a single
-    ``submit_format_config`` tool.  The agent calls the tool with a candidate
-    config; validation errors (Pydantic, DSL, dry-run) are returned as tool
-    result strings so the agent can self-correct up to *max_retries* times.
+    Wraps plain LangChain models in :class:`LangChainLLMBackend` automatically.
+    Validation errors (Pydantic, DSL, dry-run) are returned as tool result strings
+    so the agent can self-correct up to *max_retries* times.
 
     Args:
         path: Path to the source data file.
         target_schema: The desired output schema.
-        llm: A LangChain ``BaseChatModel`` instance.
+        llm: An :class:`LLMBackend` or LangChain-compatible model instance.
         example_configs: Optional existing FormatConfigs to include as examples.
         format_name: Name for the generated config. Defaults to the file stem.
         max_retries: Number of additional attempts after the first failure.
@@ -179,93 +267,29 @@ def generate_config(
         A validated :class:`~schemashift.models.FormatConfig`.
 
     Raises:
-        LLMGenerationError: When the agent fails to produce a valid config.
+        LLMGenerationError: When the backend fails to produce a valid config.
             ``error.attempts`` contains per-attempt details.
     """
-    try:
-        from langchain.agents import create_agent
-        from langchain_core.messages import HumanMessage
-        from langchain_core.tools import tool
-    except ImportError as exc:
-        raise ImportError("langchain is not installed. Run: pip install 'schemashift[llm]'") from exc
-
     df: pl.DataFrame = read_file(path, reader_config).head(n_sample_rows).collect()  # ty: ignore[invalid-assignment]
     inferred_name = format_name if format_name is not None else Path(path).stem
     prompt = build_prompt(df, target_schema, list(df.columns), example_configs, inferred_name, user_prompt=user_prompt)
 
-    # Side-channels: the tool captures its result and all attempt records here.
-    result_box: list[FormatConfig] = []
-    all_attempts: list[dict[str, Any]] = []
+    backend: LLMBackend = llm if isinstance(llm, LLMBackend) else LangChainLLMBackend(llm, max_retries=max_retries)
 
-    @tool
-    def submit_format_config(
-        columns: list[dict],
-        name: str = "",
-        description: str = "",
-        drop_unmapped: bool = True,
-    ) -> str:
-        """Submit the generated FormatConfig mapping source columns to the target schema.
-
-        Each column dict must contain 'target' and exactly one of: 'source' (direct
-        column rename), 'expr' (DSL expression string), or 'constant' (literal value).
-        Optional per-column keys: 'dtype' (cast type), 'fillna' (fill-null value).
-        Returns 'Config accepted.' on success, or an error description to fix and retry.
-        """
-        data: dict[str, Any] = {
-            "name": name or inferred_name,
-            "description": description,
-            "columns": columns,
-            "drop_unmapped": drop_unmapped,
-        }
-
-        try:
-            config = FormatConfig.model_validate(data)
-        except (ValidationError, Exception) as exc:
-            error = str(exc)
-            all_attempts.append({"response": data, "error": error})
-            _log.warning("FormatConfig validation attempt failed: %s", error)
-            return f"Validation error: {error}"
-
-        dsl_errors = validate_config(config)
-        if dsl_errors:
-            error = "\n".join(dsl_errors)
-            all_attempts.append({"response": data, "error": error})
-            _log.warning("FormatConfig validation attempt failed: %s", error)
-            return f"DSL errors:\n{error}"
-
-        try:
-            dry_run(config, path, n_rows=5)
-        except Exception as exc:
-            error = str(exc)
-            all_attempts.append({"response": data, "error": error})
-            _log.warning("FormatConfig validation attempt failed: %s", error)
-            return f"Runtime error during dry run: {error}"
-
-        all_attempts.append({"response": data, "error": None})
-        result_box.append(config)
-        return "Config accepted."
-
-    # Each agent step is one LLM call + one tool call = 2 graph nodes.
-    # Add a small buffer for the final LLM "I'm done" step.
-    recursion_limit = (max_retries + 1) * 3 + 2
-
-    agent = create_agent(llm, [submit_format_config])
     try:
-        agent.invoke(
-            {"messages": [HumanMessage(content=prompt)]},
-            config={"recursion_limit": recursion_limit},
+        data = backend.generate(
+            prompt,
+            {
+                "format_name": inferred_name,
+                "path": path,
+            },
         )
+    except LLMGenerationError:
+        raise
     except Exception as exc:
-        if result_box:
-            return result_box[0]
-        if not all_attempts:
-            all_attempts.append({"response": "", "error": str(exc)})
-        raise LLMGenerationError(str(exc), attempts=all_attempts) from exc
+        attempts = list(getattr(backend, "attempts", []))
+        if not attempts:
+            attempts.append({"response": "", "error": str(exc)})
+        raise LLMGenerationError(str(exc), attempts=attempts) from exc
 
-    if result_box:
-        return result_box[0]
-
-    raise LLMGenerationError(
-        "Agent completed without submitting a valid config",
-        attempts=all_attempts,
-    )
+    return FormatConfig.model_validate(data)

--- a/src/schemashift/llm.py
+++ b/src/schemashift/llm.py
@@ -2,10 +2,13 @@
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
 from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
 
 from . import dsl as _dsl_module
 from .errors import LLMGenerationError
@@ -143,7 +146,7 @@ def build_prompt(
 def generate_config(
     path: str,
     target_schema: TargetSchema,
-    llm: Any,  # ANNOT: use stronger typing
+    llm: "BaseChatModel",
     example_configs: list[FormatConfig] | None = None,
     format_name: str | None = None,
     max_retries: int = 2,

--- a/src/schemashift/llm.py
+++ b/src/schemashift/llm.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 
 from . import dsl as _dsl_module
 from .errors import LLMGenerationError
-from .models import FormatConfig
+from .models import FormatConfig, ReaderConfig
 from .readers import read_file
 from .target_schema import TargetSchema
 from .transform import dry_run, validate_config
@@ -149,6 +149,7 @@ def generate_config(
     max_retries: int = 2,
     n_sample_rows: int = 15,
     user_prompt: str | None = None,
+    reader_config: ReaderConfig | None = None,
 ) -> FormatConfig:
     """Generate a FormatConfig for the given file using the LangChain agent API.
 
@@ -167,6 +168,9 @@ def generate_config(
         n_sample_rows: Number of rows to sample from the file for the prompt.
         user_prompt: Optional extra context for the LLM (e.g. unit conventions,
             timestamp formats).
+        reader_config: Optional reader configuration forwarded to :func:`read_file`
+            when sampling rows. Required for files with non-default separators or
+            skip_rows.
 
     Returns:
         A validated :class:`~schemashift.models.FormatConfig`.
@@ -182,7 +186,7 @@ def generate_config(
     except ImportError as exc:
         raise ImportError("langchain is not installed. Run: pip install 'schemashift[llm]'") from exc
 
-    df: pl.DataFrame = read_file(path).head(n_sample_rows).collect()  # ty: ignore[invalid-assignment]
+    df: pl.DataFrame = read_file(path, reader_config).head(n_sample_rows).collect()  # ty: ignore[invalid-assignment]
     inferred_name = format_name if format_name is not None else Path(path).stem
     prompt = build_prompt(df, target_schema, list(df.columns), example_configs, inferred_name, user_prompt=user_prompt)
 

--- a/src/schemashift/models.py
+++ b/src/schemashift/models.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from .dsl import collect_col_refs, parse_dsl
 from .dtypes import DTYPE_MAP
 from .errors import ConfigValidationError
 
@@ -11,49 +12,6 @@ from .errors import ConfigValidationError
 # Using PydanticUndefined as a default makes Pydantic treat the field as required,
 # so we define our own sentinel object instead.
 _UNSET: Any = object()
-
-
-def _col_refs_from_expr(expr: str) -> set[str]:
-    """Walk a DSL AST and return all referenced column names."""
-    from schemashift.dsl.ast_nodes import (
-        BinaryOp,
-        Coalesce,
-        ColRef,
-        CustomLookup,
-        Lookup,
-        MethodCall,
-        UnaryOp,
-        WhenChain,
-    )
-    from schemashift.dsl.parser import parse_dsl
-
-    ASTNode = object  # local alias for type hints only
-
-    def walk(node: ASTNode) -> set[str]:
-        match node:
-            case ColRef(name):
-                return {name}
-            case BinaryOp(_, left, right):
-                return walk(left) | walk(right)
-            case UnaryOp(_, operand):
-                return walk(operand)
-            case MethodCall(obj, _, args):
-                return walk(obj) | {r for a in args for r in walk(a)}
-            case WhenChain(whens, otherwise):
-                refs = walk(otherwise)
-                for clause in whens:
-                    refs |= walk(clause.condition) | walk(clause.value)
-                return refs
-            case Coalesce(exprs):
-                return {r for e in exprs for r in walk(e)}
-            case Lookup(inner, _):
-                return walk(inner)
-            case CustomLookup(inner, _, _):
-                return walk(inner)
-            case _:
-                return set()
-
-    return walk(parse_dsl(expr))
 
 
 _DTYPE_JSON_SCHEMA: dict[str, Any] = {
@@ -202,5 +160,5 @@ class FormatConfig(BaseModel):
             if mapping.source is not None:
                 cols.add(mapping.source)
             if mapping.expr is not None:
-                cols.update(_col_refs_from_expr(mapping.expr))
+                cols.update(collect_col_refs(parse_dsl(mapping.expr)))
         return cols

--- a/src/schemashift/models.py
+++ b/src/schemashift/models.py
@@ -11,7 +11,12 @@ from .errors import ConfigValidationError
 # Matches col("column_name") in DSL expressions.
 _COL_PATTERN: re.Pattern[str] = re.compile(r'col\("([^"]+)"\)')
 
-_DTYPE_JSON_SCHEMA: dict = {
+# Sentinel for optional Any-typed fields where None is a valid user-supplied value.
+# Using PydanticUndefined as a default makes Pydantic treat the field as required,
+# so we define our own sentinel object instead.
+_UNSET: Any = object()
+
+_DTYPE_JSON_SCHEMA: dict[str, Any] = {
     "anyOf": [
         {"enum": sorted(DTYPE_MAP), "type": "string"},
         {"type": "null"},
@@ -36,14 +41,36 @@ class ColumnMapping(BaseModel):
         ),
     )
     constant: Any = Field(
-        default=None, description="Literal constant broadcast to all rows. Mutually exclusive with 'source' and 'expr'."
+        default=_UNSET,
+        description="Literal constant broadcast to all rows. Mutually exclusive with 'source' and 'expr'.",
     )
     dtype: str | None = Field(
         default=None,
         description="Target Polars dtype to cast this column to after mapping.",
         json_schema_extra=_DTYPE_JSON_SCHEMA,
     )
-    fillna: Any = Field(default=None, description="Fill-value applied to nulls after mapping.")
+    fillna: Any = Field(default=_UNSET, description="Fill-value applied to nulls after mapping.")
+
+    def has_constant(self) -> bool:
+        return self.constant is not _UNSET
+
+    def has_fillna(self) -> bool:
+        return self.fillna is not _UNSET
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        """Override to omit sentinel-valued fields from the output dict."""
+        d = super().model_dump(**kwargs)
+        if d.get("constant") is _UNSET:
+            d.pop("constant", None)
+        if d.get("fillna") is _UNSET:
+            d.pop("fillna", None)
+        return d
+
+    def model_dump_json(self, **kwargs: Any) -> str:
+        """Override to omit sentinel-valued fields from the JSON output."""
+        import json
+
+        return json.dumps(self.model_dump(**kwargs))
 
     @model_validator(mode="after")
     def _exactly_one_source_set(self) -> "ColumnMapping":
@@ -51,7 +78,7 @@ class ColumnMapping(BaseModel):
             [
                 self.source is not None,
                 self.expr is not None,
-                self.constant is not None,
+                self.has_constant(),
             ]
         )
         if set_fields != 1:
@@ -94,6 +121,20 @@ class FormatConfig(BaseModel):
     reader: ReaderConfig = Field(default_factory=ReaderConfig, description="Low-level reader options.")
     columns: list[ColumnMapping] = Field(description="Ordered list of column mappings defining the output schema.")
     drop_unmapped: bool = Field(default=True, description="Drop source columns not referenced by any mapping.")
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        """Override to serialise ColumnMapping fields respecting the _UNSET sentinel."""
+        d = super().model_dump(**kwargs)
+        # Replace raw column dicts with ones produced by ColumnMapping.model_dump()
+        d["columns"] = [col.model_dump(**kwargs) for col in self.columns]
+        return d
+
+    def model_dump_json(self, **kwargs: Any) -> str:
+        """Override to serialise ColumnMapping fields respecting the _UNSET sentinel."""
+        import json
+
+        indent = kwargs.pop("indent", None)
+        return json.dumps(self.model_dump(**kwargs), indent=indent)
 
     @model_validator(mode="after")
     def _unique_target_names(self) -> "FormatConfig":

--- a/src/schemashift/models.py
+++ b/src/schemashift/models.py
@@ -1,6 +1,5 @@
 """Pydantic v2 models for schemashift configuration."""
 
-import re
 from typing import Any
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -8,13 +7,54 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from .dtypes import DTYPE_MAP
 from .errors import ConfigValidationError
 
-# Matches col("column_name") in DSL expressions.
-_COL_PATTERN: re.Pattern[str] = re.compile(r'col\("([^"]+)"\)')
-
 # Sentinel for optional Any-typed fields where None is a valid user-supplied value.
 # Using PydanticUndefined as a default makes Pydantic treat the field as required,
 # so we define our own sentinel object instead.
 _UNSET: Any = object()
+
+
+def _col_refs_from_expr(expr: str) -> set[str]:
+    """Walk a DSL AST and return all referenced column names."""
+    from schemashift.dsl.ast_nodes import (
+        BinaryOp,
+        Coalesce,
+        ColRef,
+        CustomLookup,
+        Lookup,
+        MethodCall,
+        UnaryOp,
+        WhenChain,
+    )
+    from schemashift.dsl.parser import parse_dsl
+
+    ASTNode = object  # local alias for type hints only
+
+    def walk(node: ASTNode) -> set[str]:
+        match node:
+            case ColRef(name):
+                return {name}
+            case BinaryOp(_, left, right):
+                return walk(left) | walk(right)
+            case UnaryOp(_, operand):
+                return walk(operand)
+            case MethodCall(obj, _, args):
+                return walk(obj) | {r for a in args for r in walk(a)}
+            case WhenChain(whens, otherwise):
+                refs = walk(otherwise)
+                for clause in whens:
+                    refs |= walk(clause.condition) | walk(clause.value)
+                return refs
+            case Coalesce(exprs):
+                return {r for e in exprs for r in walk(e)}
+            case Lookup(inner, _):
+                return walk(inner)
+            case CustomLookup(inner, _, _):
+                return walk(inner)
+            case _:
+                return set()
+
+    return walk(parse_dsl(expr))
+
 
 _DTYPE_JSON_SCHEMA: dict[str, Any] = {
     "anyOf": [
@@ -154,12 +194,13 @@ class FormatConfig(BaseModel):
     def source_columns(self) -> set[str]:
         """Return all source column names referenced in this config.
 
-        Includes direct 'source' fields and col("...") references inside 'expr' fields.
+        Includes direct 'source' fields and all col("...") references inside 'expr' fields,
+        extracted by walking the DSL AST rather than regex-matching strings.
         """
         cols: set[str] = set()
         for mapping in self.columns:
             if mapping.source is not None:
                 cols.add(mapping.source)
             if mapping.expr is not None:
-                cols.update(_COL_PATTERN.findall(mapping.expr))
+                cols.update(_col_refs_from_expr(mapping.expr))
         return cols

--- a/src/schemashift/models.py
+++ b/src/schemashift/models.py
@@ -76,7 +76,7 @@ class ReaderConfig(BaseModel):
 
     skip_rows: int = Field(default=0, description="Number of rows to skip before the header.", ge=0)
     sheet_name: str | int | None = Field(
-        default=None, description="Excel sheet name (string) or 1-based index (int). Ignored for non-Excel files."
+        default=None, description="Excel sheet name (string) or 0-based index (int). Ignored for non-Excel files."
     )
     separator: str | None = Field(default=None, description="CSV field delimiter. Auto-detected when null.")
     encoding: str = Field(default="utf-8", description="Character encoding of the source file.")

--- a/src/schemashift/orchestration.py
+++ b/src/schemashift/orchestration.py
@@ -1,0 +1,177 @@
+"""Higher-level orchestration flows built on top of the core transform engine."""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from schemashift.errors import FormatDetectionError, ReviewRejectedError
+from schemashift.models import FormatConfig, ReaderConfig
+from schemashift.readers import read_header
+from schemashift.registry import Registry
+from schemashift.transform import dry_run, transform
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+    from schemashift.target_schema import TargetSchema
+
+
+def auto_transform(
+    path: str | Path,
+    registry: Registry,
+    reader_config: ReaderConfig | None = None,
+) -> pl.LazyFrame:
+    """Auto-detect the format from the registry and transform the file.
+
+    Args:
+        path: Path to the source file.
+        registry: Registry to search for a matching config.
+        reader_config: Optional reader configuration used when reading the file
+            header for format detection.
+
+    Returns:
+        A transformed :class:`polars.LazyFrame`.
+
+    Raises:
+        FormatDetectionError: When no config matches the file's columns.
+        AmbiguousFormatError: When multiple configs match.
+    """
+    config = _detect_config(path, registry, reader_config)
+    if config is None:
+        columns = read_header(path, reader_config)
+        raise FormatDetectionError(
+            f"No registered config matches the columns found in '{path}'. Columns present: {columns}"
+        )
+    return transform(path, config)
+
+
+def smart_transform(
+    path: str | Path,
+    registry: Registry,
+    target_schema: "TargetSchema | None" = None,
+    llm: "BaseChatModel | None" = None,
+    review_fn: Callable[[FormatConfig, pl.DataFrame], FormatConfig | None] | None = None,
+    auto_register: bool = False,
+    example_configs: list[FormatConfig] | None = None,
+    max_retries: int = 2,
+    n_sample_rows: int = 15,
+    reader_config: ReaderConfig | None = None,
+) -> pl.LazyFrame:
+    """Full detect-or-generate flow.
+
+    1. Try auto-detect from registry.
+    2. If miss and LLM available: generate config.
+    3. If review_fn provided: pass config + sample to reviewer.
+    4. If auto_register: save to registry.
+    5. Apply config; optionally validate against target_schema.
+
+    Args:
+        path: Source file path.
+        registry: Registry to search and optionally register to.
+        target_schema: Required for LLM generation and output validation.
+        llm: LangChain BaseChatModel.
+        review_fn: callback(config, sample_df) -> config | None. None = reject.
+        auto_register: Register LLM-generated config automatically.
+        example_configs: Example configs for LLM prompt.
+        max_retries: Max LLM retries.
+        n_sample_rows: Rows to sample for LLM.
+        reader_config: Optional reader configuration forwarded to all file reads.
+
+    Returns:
+        Transformed pl.LazyFrame.
+
+    Raises:
+        FormatDetectionError: No match and no LLM.
+        ValueError: LLM needed but target_schema not provided.
+        LLMGenerationError: LLM fails after all retries.
+        ReviewRejectedError: review_fn returned None.
+    """
+    config = _resolve_config(
+        path=path,
+        registry=registry,
+        target_schema=target_schema,
+        llm=llm,
+        review_fn=review_fn,
+        auto_register=auto_register,
+        example_configs=example_configs,
+        max_retries=max_retries,
+        n_sample_rows=n_sample_rows,
+        reader_config=reader_config,
+    )
+    lf = transform(path, config)
+    if target_schema is not None:
+        target_schema.validate_lazy(lf)
+    return lf
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _detect_config(
+    path: str | Path,
+    registry: Registry,
+    reader_config: ReaderConfig | None = None,
+) -> FormatConfig | None:
+    from schemashift.detection import detect_format
+
+    return detect_format(read_header(path, reader_config), registry)
+
+
+def _resolve_config(
+    path: str | Path,
+    registry: Registry,
+    target_schema: "TargetSchema | None",
+    llm: "BaseChatModel | None",
+    review_fn: Callable[[FormatConfig, pl.DataFrame], FormatConfig | None] | None,
+    auto_register: bool,
+    example_configs: list[FormatConfig] | None,
+    max_retries: int,
+    n_sample_rows: int,
+    reader_config: ReaderConfig | None = None,
+) -> FormatConfig:
+    config = _detect_config(path, registry, reader_config)
+    if config is not None:
+        return config
+
+    columns = read_header(path, reader_config)
+    if llm is None:
+        raise FormatDetectionError(
+            f"No registered config matches '{path}' and no LLM is configured. File columns: {columns}"
+        )
+    if target_schema is None:
+        raise ValueError("target_schema is required for LLM config generation")
+
+    from schemashift.llm import generate_config
+
+    generated = generate_config(
+        path=str(path),
+        target_schema=target_schema,
+        llm=llm,
+        example_configs=example_configs,
+        max_retries=max_retries,
+        n_sample_rows=n_sample_rows,
+        reader_config=reader_config,
+    )
+    reviewed = _review_generated_config(path, generated, review_fn)
+    if auto_register:
+        registry.register(reviewed)
+    return reviewed
+
+
+def _review_generated_config(
+    path: str | Path,
+    config: FormatConfig,
+    review_fn: Callable[[FormatConfig, pl.DataFrame], FormatConfig | None] | None,
+) -> FormatConfig:
+    if review_fn is None:
+        return config
+
+    sample_df = dry_run(config, path, n_rows=10)
+    reviewed = review_fn(config, sample_df)
+    if reviewed is None:
+        raise ReviewRejectedError("Config was rejected by review_fn")
+    return reviewed

--- a/src/schemashift/readers.py
+++ b/src/schemashift/readers.py
@@ -1,6 +1,8 @@
 """File readers that return Polars LazyFrames."""
 
+import codecs
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 
@@ -76,11 +78,16 @@ def read_header(path: str | Path, config: ReaderConfig | None = None) -> list[st
 def _normalise_csv_encoding(encoding: str) -> str:
     """Normalise encoding strings for Polars scan_csv.
 
-    Polars scan_csv only accepts 'utf8' or 'utf8-lossy'.  Common aliases like
-    'utf-8' must be converted before passing through.
+    Polars scan_csv only accepts 'utf8' or 'utf8-lossy'.  Resolve the
+    canonical codec name first (so 'utf-8', 'UTF-8', 'utf_8' all normalise
+    to 'utf-8'), then map the utf-8 family to the 'utf8' token Polars expects.
     """
-    _ALIAS_MAP: dict[str, str] = {"utf-8": "utf8", "UTF-8": "utf8", "UTF8": "utf8"}
-    return _ALIAS_MAP.get(encoding, encoding)
+    try:
+        canonical = codecs.lookup(encoding).name  # e.g. 'utf-8', 'latin-1'
+    except LookupError:
+        return encoding  # let Polars surface its own error
+    _POLARS_MAP: dict[str, str] = {"utf-8": "utf8", "utf-8-sig": "utf8"}
+    return _POLARS_MAP.get(canonical, canonical)
 
 
 def _read_csv(path: Path, cfg: ReaderConfig, default_sep: str) -> pl.LazyFrame:
@@ -94,7 +101,7 @@ def _read_csv(path: Path, cfg: ReaderConfig, default_sep: str) -> pl.LazyFrame:
 
 
 def _read_excel(path: Path, cfg: ReaderConfig) -> pl.LazyFrame:
-    kwargs: dict = {}
+    kwargs: dict[str, Any] = {}
 
     # sheet_name accepts a string name; integers are treated as 0-based sheet
     # indices and mapped to the 1-based sheet_id parameter that pl.read_excel

--- a/src/schemashift/registry.py
+++ b/src/schemashift/registry.py
@@ -35,6 +35,10 @@ class Registry(ABC):
         Returns True if the config existed and was removed, False otherwise.
         """
 
+    def load_schema(self, name: str | None = None) -> "TargetSchema | None":
+        """Load a target schema associated with this registry, if supported."""
+        return None
+
 
 class DictRegistry(Registry):
     """In-memory registry suitable for testing and embedded use."""
@@ -108,25 +112,36 @@ class FileSystemRegistry(Registry):
 
         If *name* is provided, loads ``{schemas_dir}/{name}.yaml`` (falling
         back to ``.yml``).  If *name* is ``None`` and exactly one schema file
-        exists, returns it.  Returns ``None`` if the ``schemas/`` directory
+        exists, returns it. Returns ``None`` if the ``schemas/`` directory
         does not exist, is empty, or the named file is not found.
+
+        Raises:
+            ValueError: If multiple schemas exist and no explicit name is given.
         """
         from schemashift.target_schema import TargetSchema
 
-        schemas_dir = self._path / "schemas"
-        if not schemas_dir.exists():
+        path = _resolve_schema_path(self._path / "schemas", name)
+        if path is None:
             return None
+        return TargetSchema.from_yaml(path)
 
-        if name is not None:
-            path = schemas_dir / f"{name}.yaml"
-            if path.exists():
-                return TargetSchema.from_yaml(path)
-            path = schemas_dir / f"{name}.yml"
-            if path.exists():
-                return TargetSchema.from_yaml(path)
-            return None
 
-        yamls = list(schemas_dir.glob("*.yaml")) + list(schemas_dir.glob("*.yml"))
-        if len(yamls) == 1:
-            return TargetSchema.from_yaml(yamls[0])
+def _resolve_schema_path(schemas_dir: Path, name: str | None = None) -> Path | None:
+    """Resolve a schema file path inside a ``schemas`` directory."""
+    if not schemas_dir.exists():
         return None
+
+    if name is not None:
+        for suffix in (".yaml", ".yml"):
+            path = schemas_dir / f"{name}{suffix}"
+            if path.exists():
+                return path
+        return None
+
+    yamls = sorted(schemas_dir.glob("*.yaml")) + sorted(schemas_dir.glob("*.yml"))
+    if not yamls:
+        return None
+    if len(yamls) > 1:
+        names = [path.name for path in yamls]
+        raise ValueError(f"Multiple schemas found in '{schemas_dir}': {names}. Use an explicit schema name.")
+    return yamls[0]

--- a/src/schemashift/registry.py
+++ b/src/schemashift/registry.py
@@ -89,8 +89,11 @@ class FileSystemRegistry(Registry):
     def list_configs(self) -> list[FormatConfig]:
         configs: list[FormatConfig] = []
         for p in sorted(self._path.glob("*.json")):
-            data = json.loads(p.read_text(encoding="utf-8"))
-            configs.append(FormatConfig.model_validate(data))
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+                configs.append(FormatConfig.model_validate(data))
+            except Exception as exc:
+                raise ConfigValidationError(f"Failed to load config from '{p}': {exc}") from exc
         return configs
 
     def delete(self, name: str) -> bool:

--- a/src/schemashift/registry.py
+++ b/src/schemashift/registry.py
@@ -1,10 +1,12 @@
 """Format config registries — in-memory and file-system backed."""
 
 import json
+import re
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from schemashift.errors import ConfigValidationError
 from schemashift.models import FormatConfig
 
 if TYPE_CHECKING:
@@ -67,6 +69,10 @@ class FileSystemRegistry(Registry):
         self._path.mkdir(parents=True, exist_ok=True)
 
     def _config_path(self, name: str) -> Path:
+        if not re.fullmatch(r"[A-Za-z0-9_\-]+", name):
+            raise ConfigValidationError(
+                f"Invalid config name {name!r}: only letters, digits, underscores, and hyphens are allowed."
+            )
         return self._path / f"{name}.json"
 
     def get(self, name: str) -> FormatConfig | None:

--- a/src/schemashift/schema/format_config.json
+++ b/src/schemashift/schema/format_config.json
@@ -125,7 +125,7 @@
             }
           ],
           "default": null,
-          "description": "Excel sheet name (string) or 1-based index (int). Ignored for non-Excel files.",
+          "description": "Excel sheet name (string) or 0-based index (int). Ignored for non-Excel files.",
           "title": "Sheet Name"
         },
         "skip_rows": {

--- a/src/schemashift/schema/format_config.json
+++ b/src/schemashift/schema/format_config.json
@@ -4,7 +4,6 @@
       "description": "Describes how to produce one output column.",
       "properties": {
         "constant": {
-          "default": null,
           "description": "Literal constant broadcast to all rows. Mutually exclusive with 'source' and 'expr'.",
           "title": "Constant"
         },
@@ -61,7 +60,6 @@
           "title": "Expr"
         },
         "fillna": {
-          "default": null,
           "description": "Fill-value applied to nulls after mapping.",
           "title": "Fillna"
         },

--- a/src/schemashift/target_schema.py
+++ b/src/schemashift/target_schema.py
@@ -6,7 +6,7 @@ import polars as pl
 import yaml
 from pydantic import BaseModel, Field
 
-from .dtypes import DTYPE_MAP, DType, polars_dtype
+from .dtypes import DType, polars_dtype
 from .errors import SchemaValidationError
 
 
@@ -97,4 +97,4 @@ def _dtypes_compatible(actual: pl.DataType, expected: type[pl.DataType]) -> bool
     return isinstance(actual, expected)
 
 
-__all__ = ["DTYPE_MAP", "DType", "polars_dtype", "TargetColumn", "TargetSchema"]
+__all__ = ["TargetColumn", "TargetSchema"]

--- a/src/schemashift/transform.py
+++ b/src/schemashift/transform.py
@@ -8,7 +8,7 @@ import polars as pl
 
 from schemashift.dsl import parse_and_compile
 from schemashift.dtypes import DTYPE_MAP
-from schemashift.errors import DSLRuntimeError, DSLSyntaxError, FormatDetectionError
+from schemashift.errors import DSLRuntimeError, DSLSyntaxError, FormatDetectionError, ReviewRejectedError
 from schemashift.models import ColumnMapping, FormatConfig, ReaderConfig
 from schemashift.readers import read_file
 from schemashift.registry import Registry
@@ -219,7 +219,7 @@ def smart_transform(
         sample_df = dry_run(config, path, n_rows=10)
         reviewed = review_fn(config, sample_df)
         if reviewed is None:
-            raise FormatDetectionError("Config was rejected by review_fn")
+            raise ReviewRejectedError("Config was rejected by review_fn")
         config = reviewed
 
     if auto_register:

--- a/src/schemashift/transform.py
+++ b/src/schemashift/transform.py
@@ -108,12 +108,14 @@ def dry_run(config: FormatConfig, path: str | Path, n_rows: int = 10) -> pl.Data
 def auto_transform(
     path: str | Path,
     registry: Registry,
+    reader_config: ReaderConfig | None = None,
 ) -> pl.LazyFrame:
     """Auto-detect the format from the registry and transform the file.
 
     Args:
         path: Path to the source file.
         registry: Registry to search for a matching config.
+        reader_config: Optional reader configuration forwarded to the file reader.
 
     Returns:
         A transformed :class:`polars.LazyFrame`.
@@ -125,7 +127,7 @@ def auto_transform(
     from schemashift.detection import detect_format
     from schemashift.readers import read_header
 
-    columns = read_header(path)
+    columns = read_header(path, reader_config)
     config = detect_format(columns, registry)
 
     if config is None:
@@ -133,7 +135,7 @@ def auto_transform(
             f"No registered config matches the columns found in '{path}'. Columns present: {columns}"
         )
 
-    return transform(path, config)
+    return transform(path, config, reader_config)
 
 
 def smart_transform(
@@ -147,6 +149,7 @@ def smart_transform(
     max_retries: int = 2,
     n_sample_rows: int = 15,
     user_prompt: str | None = None,
+    reader_config: ReaderConfig | None = None,
 ) -> pl.LazyFrame:
     """Full detect-or-generate flow.
 
@@ -167,6 +170,7 @@ def smart_transform(
         max_retries: Max LLM retries.
         n_sample_rows: Rows to sample for LLM.
         user_prompt: Additional context for the LLM (e.g. unit conventions).
+        reader_config: Optional reader configuration forwarded to all file reads.
 
     Returns:
         Transformed pl.LazyFrame.
@@ -180,11 +184,11 @@ def smart_transform(
     from schemashift.readers import read_header
 
     # Try registry
-    columns = read_header(path)
+    columns = read_header(path, reader_config)
     config = detect_format(columns, registry)
 
     if config is not None:
-        lf = transform(path, config)
+        lf = transform(path, config, reader_config)
         if target_schema is not None:
             target_schema.validate_lazy(lf)
         return lf
@@ -207,6 +211,7 @@ def smart_transform(
         max_retries=max_retries,
         n_sample_rows=n_sample_rows,
         user_prompt=user_prompt,
+        reader_config=reader_config,
     )
 
     # Review callback
@@ -220,7 +225,7 @@ def smart_transform(
     if auto_register:
         registry.register(config)
 
-    lf = transform(path, config)
+    lf = transform(path, config, reader_config)
     if target_schema is not None:
         target_schema.validate_lazy(lf)
     return lf

--- a/src/schemashift/transform.py
+++ b/src/schemashift/transform.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import polars as pl
 
@@ -14,6 +14,8 @@ from schemashift.readers import read_file
 from schemashift.registry import Registry
 
 if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
     from schemashift.target_schema import TargetSchema
 
 
@@ -142,7 +144,7 @@ def smart_transform(
     path: str | Path,
     registry: Registry,
     target_schema: "TargetSchema | None" = None,
-    llm: Any = None,  # ANNOT: the typing here should be stronger
+    llm: "BaseChatModel | None" = None,
     review_fn: Callable[[FormatConfig, pl.DataFrame], FormatConfig | None] | None = None,
     auto_register: bool = False,
     example_configs: list[FormatConfig] | None = None,

--- a/src/schemashift/transform.py
+++ b/src/schemashift/transform.py
@@ -1,23 +1,14 @@
 """Core transform engine: apply a FormatConfig to a file."""
 
-from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import polars as pl
 
 from schemashift.dsl import parse_and_compile
 from schemashift.dtypes import DTYPE_MAP
-from schemashift.errors import DSLRuntimeError, DSLSyntaxError, FormatDetectionError, ReviewRejectedError
-from schemashift.models import ColumnMapping, FormatConfig, ReaderConfig
+from schemashift.errors import DSLSyntaxError
+from schemashift.models import ColumnMapping, FormatConfig
 from schemashift.readers import read_file
-from schemashift.registry import Registry
-
-if TYPE_CHECKING:
-    from langchain_core.language_models import BaseChatModel
-
-    from schemashift.target_schema import TargetSchema
-
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -27,7 +18,6 @@ if TYPE_CHECKING:
 def transform(
     path: str | Path,
     config: FormatConfig,
-    reader_config: ReaderConfig | None = None,
 ) -> pl.LazyFrame:
     """Apply a FormatConfig to a file and return a transformed LazyFrame.
 
@@ -41,8 +31,6 @@ def transform(
     Args:
         path: Path to the source file.
         config: FormatConfig describing how to map columns.
-        reader_config: Optional low-level reader options (overrides
-            ``config.reader`` when provided).
 
     Returns:
         A :class:`polars.LazyFrame` with the transformed columns.
@@ -51,8 +39,7 @@ def transform(
         DSLRuntimeError: When a DSL expression fails to evaluate.
         ReaderError: When the file cannot be read.
     """
-    effective_reader = reader_config if reader_config is not None else config.reader
-    lf = read_file(path, effective_reader)
+    lf = read_file(path, config.reader)
     expressions = _build_expressions(config)
 
     if config.drop_unmapped:
@@ -107,131 +94,6 @@ def dry_run(config: FormatConfig, path: str | Path, n_rows: int = 10) -> pl.Data
     return result
 
 
-def auto_transform(
-    path: str | Path,
-    registry: Registry,
-    reader_config: ReaderConfig | None = None,
-) -> pl.LazyFrame:
-    """Auto-detect the format from the registry and transform the file.
-
-    Args:
-        path: Path to the source file.
-        registry: Registry to search for a matching config.
-        reader_config: Optional reader configuration forwarded to the file reader.
-
-    Returns:
-        A transformed :class:`polars.LazyFrame`.
-
-    Raises:
-        FormatDetectionError: When no config matches the file's columns.
-        AmbiguousFormatError: When multiple configs match.
-    """
-    from schemashift.detection import detect_format
-    from schemashift.readers import read_header
-
-    columns = read_header(path, reader_config)
-    config = detect_format(columns, registry)
-
-    if config is None:
-        raise FormatDetectionError(
-            f"No registered config matches the columns found in '{path}'. Columns present: {columns}"
-        )
-
-    return transform(path, config, reader_config)
-
-
-def smart_transform(
-    path: str | Path,
-    registry: Registry,
-    target_schema: "TargetSchema | None" = None,
-    llm: "BaseChatModel | None" = None,
-    review_fn: Callable[[FormatConfig, pl.DataFrame], FormatConfig | None] | None = None,
-    auto_register: bool = False,
-    example_configs: list[FormatConfig] | None = None,
-    max_retries: int = 2,
-    n_sample_rows: int = 15,
-    user_prompt: str | None = None,
-    reader_config: ReaderConfig | None = None,
-) -> pl.LazyFrame:
-    """Full detect-or-generate flow.
-
-    1. Try auto-detect from registry.
-    2. If miss and LLM available: generate config.
-    3. If review_fn provided: pass config + sample to reviewer.
-    4. If auto_register: save to registry.
-    5. Apply config; optionally validate against target_schema.
-
-    Args:
-        path: Source file path.
-        registry: Registry to search and optionally register to.
-        target_schema: Required for LLM generation and output validation.
-        llm: LangChain BaseChatModel.
-        review_fn: callback(config, sample_df) -> config | None. None = reject.
-        auto_register: Register LLM-generated config automatically.
-        example_configs: Example configs for LLM prompt.
-        max_retries: Max LLM retries.
-        n_sample_rows: Rows to sample for LLM.
-        user_prompt: Additional context for the LLM (e.g. unit conventions).
-        reader_config: Optional reader configuration forwarded to all file reads.
-
-    Returns:
-        Transformed pl.LazyFrame.
-
-    Raises:
-        FormatDetectionError: No match and no LLM, or review_fn rejected.
-        ValueError: LLM needed but target_schema not provided.
-        LLMGenerationError: LLM fails after all retries.
-    """
-    from schemashift.detection import detect_format
-    from schemashift.readers import read_header
-
-    # Try registry
-    columns = read_header(path, reader_config)
-    config = detect_format(columns, registry)
-
-    if config is not None:
-        lf = transform(path, config, reader_config)
-        if target_schema is not None:
-            target_schema.validate_lazy(lf)
-        return lf
-
-    # No match — need LLM
-    if llm is None:
-        raise FormatDetectionError(
-            f"No registered config matches '{path}' and no LLM is configured. File columns: {columns}"
-        )
-    if target_schema is None:
-        raise ValueError("target_schema is required for LLM config generation")
-
-    from schemashift.llm import generate_config as _llm_generate
-
-    config = _llm_generate(
-        path=str(path),
-        target_schema=target_schema,
-        llm=llm,
-        example_configs=example_configs,
-        max_retries=max_retries,
-        n_sample_rows=n_sample_rows,
-        user_prompt=user_prompt,
-        reader_config=reader_config,
-    )
-
-    # Review callback
-    if review_fn is not None:
-        sample_df = dry_run(config, path, n_rows=10)
-        reviewed = review_fn(config, sample_df)
-        if reviewed is None:
-            raise ReviewRejectedError("Config was rejected by review_fn")
-        config = reviewed
-
-    if auto_register:
-        registry.register(config)
-
-    lf = transform(path, config, reader_config)
-    if target_schema is not None:
-        target_schema.validate_lazy(lf)
-    return lf
-
 
 # ---------------------------------------------------------------------------
 # Private helpers
@@ -254,14 +116,7 @@ def _mapping_to_expr(mapping: ColumnMapping) -> pl.Expr:
     if mapping.source is not None:
         expr = pl.col(mapping.source).alias(mapping.target)
     elif mapping.expr is not None:
-        try:
-            compiled = parse_and_compile(mapping.expr)
-        except DSLSyntaxError as exc:
-            raise DSLRuntimeError(
-                f"DSL syntax error for target '{mapping.target}': {exc}",
-                expression=mapping.expr,
-                target=mapping.target,
-            ) from exc
+        compiled = parse_and_compile(mapping.expr)
         expr = compiled.alias(mapping.target)
     elif mapping.has_constant():
         # constant (may be None, broadcasting nulls)

--- a/src/schemashift/transform.py
+++ b/src/schemashift/transform.py
@@ -256,8 +256,8 @@ def _mapping_to_expr(mapping: ColumnMapping) -> pl.Expr:
                 target=mapping.target,
             ) from exc
         expr = compiled.alias(mapping.target)
-    elif mapping.constant is not None:
-        # constant
+    elif mapping.has_constant():
+        # constant (may be None, broadcasting nulls)
         expr = pl.lit(mapping.constant).alias(mapping.target)
     else:
         raise ValueError(f"ColumnMapping {mapping} has neither source nor expr nor constant")
@@ -269,7 +269,7 @@ def _mapping_to_expr(mapping: ColumnMapping) -> pl.Expr:
             expr = expr.cast(dtype)
 
     # Apply fill_null
-    if mapping.fillna is not None:
+    if mapping.has_fillna():
         expr = expr.fill_null(pl.lit(mapping.fillna))
 
     return expr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
-"""Shared pytest configuration and fixtures."""
+"""Shared test fixtures and helpers."""
 
 import os
 
 import pytest
+
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage
 
 
 def pytest_collection_modifyitems(config, items):
@@ -15,3 +18,25 @@ def pytest_collection_modifyitems(config, items):
             for item in items:
                 if item.get_closest_marker("llm"):
                     item.add_marker(skip)
+
+class FakeToolCallingModel(FakeMessagesListChatModel):
+    """Minimal fake LLM that supports tool-calling for use with create_agent."""
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+def make_tool_calling_llm(*tool_call_args: dict | None) -> FakeToolCallingModel:
+    """Build a fake LLM that makes tool calls in sequence then finishes."""
+    responses: list[AIMessage] = []
+    for index, args in enumerate(tool_call_args):
+        if args is None:
+            continue
+        responses.append(
+            AIMessage(
+                content="",
+                tool_calls=[{"id": f"tc{index}", "name": "submit_format_config", "args": args}],
+            )
+        )
+    responses.append(AIMessage(content="Done."))
+    return FakeToolCallingModel(responses=responses)

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -59,14 +59,13 @@ class TestDetectFormat:
         assert "format_b" in exc_info.value.candidates
 
     def test_partial_match_file_has_extra_columns(self) -> None:
-        """File has more columns than the config needs — should still match."""
+        """Low-specificity matches fall below the default threshold."""
         reg = DictRegistry()
         cfg = _make_config("minimal", ["id"])
         reg.register(cfg)
 
         result = detect_format(["id", "name", "amount", "category", "active"], reg)
-        assert result is not None
-        assert result.name == "minimal"
+        assert result is None
 
     def test_empty_registry_returns_none(self) -> None:
         reg = DictRegistry()
@@ -116,3 +115,20 @@ class TestDetectFormat:
         result = detect_format(["col_a", "col_b", "extra"], reg)
         assert result is not None
         assert result.name == "matching"
+
+    def test_prefers_more_specific_match(self) -> None:
+        reg = DictRegistry()
+        reg.register(_make_config("minimal", ["id", "amount"]))
+        reg.register(_make_config("specific", ["id", "amount", "name"]))
+
+        result = detect_format(["id", "amount", "name"], reg)
+        assert result is not None
+        assert result.name == "specific"
+
+    def test_threshold_can_be_overridden(self) -> None:
+        reg = DictRegistry()
+        reg.register(_make_config("minimal", ["id"]))
+
+        result = detect_format(["id", "name", "amount", "category", "active"], reg, min_score=0.2)
+        assert result is not None
+        assert result.name == "minimal"

--- a/tests/test_dsl_compiler.py
+++ b/tests/test_dsl_compiler.py
@@ -444,6 +444,17 @@ class TestDatetimeMethodsExtended:
         # 2024 row should have a larger timestamp than the 2023 row.
         assert ts_list[1] < ts_list[0]
 
+    def test_dt_timestamp_explicit_unit(self, datetime_df: pl.DataFrame) -> None:
+        result = datetime_df.select(parse_and_compile('col("ts").dt.timestamp("us")').alias("out"))
+        ts_list = result["out"].to_list()
+        assert all(t > 0 for t in ts_list)  # type: ignore[operator]
+
+    def test_dt_timestamp_invalid_unit_raises(self, datetime_df: pl.DataFrame) -> None:
+        from schemashift.errors import DSLSyntaxError
+
+        with pytest.raises(DSLSyntaxError, match="unit"):
+            datetime_df.select(parse_and_compile('col("ts").dt.timestamp("s")').alias("out"))
+
 
 # ---------------------------------------------------------------------------
 # Compiler error paths

--- a/tests/test_dsl_compiler.py
+++ b/tests/test_dsl_compiler.py
@@ -410,6 +410,11 @@ class TestLogicalCompiled:
         result = df.select(parse_and_compile('col("X") == 1 | col("X") == 10').alias("out"))["out"].to_list()
         assert result == [True, False, True]
 
+    def test_logical_not(self) -> None:
+        df = pl.DataFrame({"flag": [True, False, True]})
+        result = df.select(parse_and_compile('not col("flag")').alias("out"))["out"].to_list()
+        assert result == [False, True, False]
+
 
 # ---------------------------------------------------------------------------
 # Datetime hour/minute/second/timestamp compiled

--- a/tests/test_dsl_parser.py
+++ b/tests/test_dsl_parser.py
@@ -200,6 +200,14 @@ class TestUnary:
     def test_double_negation(self) -> None:
         assert parse_dsl("-(-1)") == UnaryOp("-", UnaryOp("-", Literal(1)))
 
+    def test_not_is_null(self) -> None:
+        node = parse_dsl('not col("X").is_null()')
+        assert node == UnaryOp("!", MethodCall(ColRef("X"), "is_null", ()))
+
+    def test_double_not(self) -> None:
+        node = parse_dsl('not not col("x").is_null()')
+        assert node == UnaryOp("!", UnaryOp("!", MethodCall(ColRef("x"), "is_null", ())))
+
 
 # ---------------------------------------------------------------------------
 # Parenthesised expressions

--- a/tests/test_dsl_security.py
+++ b/tests/test_dsl_security.py
@@ -237,3 +237,18 @@ class TestCastValidation:
         for t in valid_types:
             result = parse_and_compile(f'col("x").cast("{t}")')
             assert isinstance(result, pl.Expr), f"Expected Expr for cast({t!r})"
+
+
+# ---------------------------------------------------------------------------
+# not keyword
+# ---------------------------------------------------------------------------
+
+
+class TestNotKeyword:
+    def test_not_produces_safe_expr(self) -> None:
+        result = parse_and_compile('not col("x").is_null()')
+        assert isinstance(result, pl.Expr)
+
+    def test_double_not_produces_safe_expr(self) -> None:
+        result = parse_and_compile('not not col("x").is_null()')
+        assert isinstance(result, pl.Expr)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -10,6 +10,7 @@ from schemashift.errors import (
     FormatDetectionError,
     LLMGenerationError,
     ReaderError,
+    ReviewRejectedError,
     SchemaShiftError,
     SchemaValidationError,
     UnsupportedFileError,
@@ -116,3 +117,15 @@ class TestSimpleErrors:
     def test_raises_and_message(self, error_cls):
         with pytest.raises(SchemaShiftError, match="test message"):
             raise error_cls("test message")
+
+
+class TestReviewRejectedError:
+    def test_is_schemashift_error(self):
+        assert issubclass(ReviewRejectedError, SchemaShiftError)
+
+    def test_not_format_detection_error(self):
+        assert not issubclass(ReviewRejectedError, FormatDetectionError)
+
+    def test_raises_with_message(self):
+        with pytest.raises(ReviewRejectedError, match="rejected"):
+            raise ReviewRejectedError("config was rejected")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,13 +11,13 @@ class TestColumnMappingValidation:
         col = ColumnMapping(target="out", source="in")
         assert col.source == "in"
         assert col.expr is None
-        assert col.constant is None
+        assert not col.has_constant()
 
     def test_expr_only_is_valid(self):
         col = ColumnMapping(target="out", expr='col("price") * 1.2')
         assert col.expr == 'col("price") * 1.2'
         assert col.source is None
-        assert col.constant is None
+        assert not col.has_constant()
 
     def test_constant_only_is_valid(self):
         col = ColumnMapping(target="flag", constant=True)
@@ -53,6 +53,23 @@ class TestColumnMappingValidation:
     def test_all_three_raises_config_error(self):
         with pytest.raises(ConfigValidationError, match="exactly one"):
             ColumnMapping(target="out", source="in", expr='col("in")', constant=0)
+
+    def test_constant_none_is_valid(self) -> None:
+        col = ColumnMapping(target="flag", constant=None)
+        assert col.has_constant() is True
+        assert col.constant is None
+
+    def test_constant_none_round_trips_json(self) -> None:
+        import json
+
+        config = FormatConfig(
+            name="test",
+            columns=[ColumnMapping(target="flag", constant=None)],
+        )
+        dumped = json.loads(config.model_dump_json())
+        reloaded = FormatConfig.model_validate(dumped)
+        assert reloaded.columns[0].constant is None
+        assert reloaded.columns[0].has_constant()
 
 
 class TestColumnMappingDtypeValidation:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -201,6 +201,20 @@ class TestFormatConfigSourceColumns:
         cfg = FormatConfig(name="f", columns=cols)
         assert cfg.source_columns() == set()
 
+    def test_single_quoted_col_refs_extracted(self):
+        cfg = FormatConfig(
+            name="f",
+            columns=[ColumnMapping(target="out", expr="col('price') * col('qty')")],
+        )
+        assert cfg.source_columns() == {"price", "qty"}
+
+    def test_nested_expr_col_refs_extracted(self):
+        cfg = FormatConfig(
+            name="f",
+            columns=[ColumnMapping(target="out", expr='coalesce(col("a"), col("b"))')],
+        )
+        assert cfg.source_columns() == {"a", "b"}
+
 
 class TestFormatConfigJsonRoundTrip:
     def test_round_trip_via_model_dump_and_validate(self):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -207,14 +207,15 @@ class TestFileSystemRegistryLoadSchema:
         assert schema is not None
         assert schema.name == "my_schema"
 
-    def test_returns_none_when_multiple_schemas_and_no_name(self, tmp_path: Path) -> None:
+    def test_raises_when_multiple_schemas_and_no_name(self, tmp_path: Path) -> None:
         schemas_dir = tmp_path / "schemas"
         schemas_dir.mkdir()
         (schemas_dir / "schema_a.yaml").write_text(_SCHEMA_YAML, encoding="utf-8")
         (schemas_dir / "schema_b.yaml").write_text(_OTHER_SCHEMA_YAML, encoding="utf-8")
 
         reg = FileSystemRegistry(tmp_path)
-        assert reg.load_schema() is None
+        with pytest.raises(ValueError, match="Multiple schemas found"):
+            reg.load_schema()
 
     def test_loads_named_schema_yaml(self, tmp_path: Path) -> None:
         schemas_dir = tmp_path / "schemas"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -264,3 +264,9 @@ class TestFileSystemRegistryLoadSchema:
     def test_hyphenated_name_accepted(self, tmp_path: Path) -> None:
         reg = FileSystemRegistry(tmp_path)
         assert reg.get("my-config") is None
+
+    def test_list_configs_corrupt_file_raises_with_path(self, tmp_path: Path) -> None:
+        reg = FileSystemRegistry(tmp_path)
+        (tmp_path / "bad.json").write_text("{invalid json", encoding="utf-8")
+        with pytest.raises(ConfigValidationError, match="bad.json"):
+            reg.list_configs()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,6 +3,9 @@
 import json
 from pathlib import Path
 
+import pytest
+
+from schemashift.errors import ConfigValidationError
 from schemashift.models import ColumnMapping, FormatConfig
 from schemashift.registry import DictRegistry, FileSystemRegistry
 
@@ -247,3 +250,17 @@ class TestFileSystemRegistryLoadSchema:
     def test_returns_none_when_named_schema_and_no_schemas_dir(self, tmp_path: Path) -> None:
         reg = FileSystemRegistry(tmp_path)
         assert reg.load_schema("any_name") is None
+
+    def test_path_traversal_rejected(self, tmp_path: Path) -> None:
+        reg = FileSystemRegistry(tmp_path)
+        with pytest.raises(ConfigValidationError):
+            reg.get("../evil")
+
+    def test_dotfile_name_rejected(self, tmp_path: Path) -> None:
+        reg = FileSystemRegistry(tmp_path)
+        with pytest.raises(ConfigValidationError):
+            reg.get(".hidden")
+
+    def test_hyphenated_name_accepted(self, tmp_path: Path) -> None:
+        reg = FileSystemRegistry(tmp_path)
+        assert reg.get("my-config") is None

--- a/tests/test_smart_transform.py
+++ b/tests/test_smart_transform.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage
 
-from schemashift.errors import FormatDetectionError
+from schemashift.errors import FormatDetectionError, ReviewRejectedError
 from schemashift.models import ColumnMapping, FormatConfig
 from schemashift.registry import DictRegistry
 from schemashift.target_schema import TargetColumn, TargetSchema
@@ -141,7 +141,7 @@ class TestReviewFn:
         assert len(lf.collect()) == 2
 
     def test_review_fn_rejection(self, sample_csv, schema):
-        with pytest.raises(FormatDetectionError, match="rejected"):
+        with pytest.raises(ReviewRejectedError, match="rejected"):
             smart_transform(
                 sample_csv,
                 registry=DictRegistry(),

--- a/tests/test_smart_transform.py
+++ b/tests/test_smart_transform.py
@@ -2,34 +2,13 @@
 
 import polars as pl
 import pytest
-from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
-from langchain_core.messages import AIMessage
+from conftest import make_tool_calling_llm
 
 from schemashift.errors import FormatDetectionError, ReviewRejectedError
 from schemashift.models import ColumnMapping, FormatConfig
+from schemashift.orchestration import smart_transform
 from schemashift.registry import DictRegistry
 from schemashift.target_schema import TargetColumn, TargetSchema
-from schemashift.transform import smart_transform
-
-
-class FakeToolCallingModel(FakeMessagesListChatModel):
-    """Minimal fake LLM that supports tool-calling for use with create_agent."""
-
-    def bind_tools(self, tools, **kwargs):
-        return self
-
-
-def _make_llm(config_args: dict) -> FakeToolCallingModel:
-    """Return a fake LLM that submits *config_args* via submit_format_config then finishes."""
-    return FakeToolCallingModel(
-        responses=[
-            AIMessage(
-                content="",
-                tool_calls=[{"id": "tc1", "name": "submit_format_config", "args": config_args}],
-            ),
-            AIMessage(content="Done."),
-        ]
-    )
 
 
 @pytest.fixture
@@ -99,7 +78,7 @@ class TestRegistryHit:
 class TestLLMGeneration:
     def test_generates_when_no_match(self, sample_csv, schema):
         reg = DictRegistry()
-        lf = smart_transform(sample_csv, registry=reg, target_schema=schema, llm=_make_llm(_valid_config()))
+        lf = smart_transform(sample_csv, registry=reg, target_schema=schema, llm=make_tool_calling_llm(_valid_config()))
         assert set(lf.collect().columns) == {"student_name", "score", "grade"}
 
     def test_auto_registers(self, sample_csv, schema):
@@ -108,7 +87,7 @@ class TestLLMGeneration:
             sample_csv,
             registry=reg,
             target_schema=schema,
-            llm=_make_llm(_valid_config()),
+            llm=make_tool_calling_llm(_valid_config()),
             auto_register=True,
         )
         assert reg.get("gen") is not None
@@ -119,7 +98,7 @@ class TestLLMGeneration:
 
     def test_raises_without_schema(self, sample_csv):
         with pytest.raises(ValueError, match="target_schema"):
-            smart_transform(sample_csv, registry=DictRegistry(), llm=_make_llm(_valid_config()))
+            smart_transform(sample_csv, registry=DictRegistry(), llm=make_tool_calling_llm(_valid_config()))
 
 
 class TestReviewFn:
@@ -133,7 +112,7 @@ class TestReviewFn:
             sample_csv,
             registry=reg,
             target_schema=schema,
-            llm=_make_llm(_valid_config()),
+            llm=make_tool_calling_llm(_valid_config()),
             review_fn=review,
             auto_register=True,
         )
@@ -146,6 +125,6 @@ class TestReviewFn:
                 sample_csv,
                 registry=DictRegistry(),
                 target_schema=schema,
-                llm=_make_llm(_valid_config()),
+                llm=make_tool_calling_llm(_valid_config()),
                 review_fn=lambda cfg, df: None,
             )

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -6,7 +6,7 @@ import polars as pl
 import pytest
 
 from schemashift.errors import AmbiguousFormatError, FormatDetectionError
-from schemashift.models import ColumnMapping, FormatConfig
+from schemashift.models import ColumnMapping, FormatConfig, ReaderConfig
 from schemashift.registry import DictRegistry
 from schemashift.transform import auto_transform, dry_run, transform, validate_config
 
@@ -332,3 +332,17 @@ class TestAutoTransform:
 
         with pytest.raises(AmbiguousFormatError):
             auto_transform(SAMPLE_CSV, reg)
+
+    def test_auto_transform_forwards_reader_config(self, tmp_path: Path) -> None:
+        csv = tmp_path / "data.csv"
+        csv.write_text("metadata\na,b\n1,2\n")
+        config = FormatConfig(
+            name="test",
+            reader=ReaderConfig(skip_rows=1),
+            columns=[ColumnMapping(target="a", source="a"), ColumnMapping(target="b", source="b")],
+        )
+        reg = DictRegistry()
+        reg.register(config)
+        result = auto_transform(str(csv), reg, reader_config=ReaderConfig(skip_rows=1)).collect()
+        assert list(result.columns) == ["a", "b"]
+        assert result.shape == (1, 2)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -131,6 +131,16 @@ class TestTransformConstantMapping:
         df = transform(SAMPLE_CSV, config).collect()
         assert df["version"].to_list() == [42] * 5
 
+    def test_constant_none_broadcasts_nulls(self, tmp_path: Path) -> None:
+        csv = tmp_path / "data.csv"
+        csv.write_text("a\n1\n2\n")
+        config = FormatConfig(
+            name="test",
+            columns=[ColumnMapping(target="flag", constant=None)],
+        )
+        result = transform(str(csv), config).collect()
+        assert result["flag"].is_null().all()
+
 
 # ---------------------------------------------------------------------------
 # Dtype casting

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -5,10 +5,11 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from schemashift.errors import AmbiguousFormatError, FormatDetectionError
+from schemashift.errors import AmbiguousFormatError, DSLSyntaxError, FormatDetectionError
 from schemashift.models import ColumnMapping, FormatConfig, ReaderConfig
+from schemashift.orchestration import auto_transform
 from schemashift.registry import DictRegistry
-from schemashift.transform import auto_transform, dry_run, transform, validate_config
+from schemashift.transform import dry_run, transform, validate_config
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -99,6 +100,14 @@ class TestTransformExprMapping:
         )
         df = transform(NUMBERS_CSV, config).collect()
         assert df["sum_col"].to_list() == pytest.approx([12.0, 24.0, 36.0])
+
+    def test_invalid_dsl_syntax_propagates_as_syntax_error(self) -> None:
+        config = FormatConfig(
+            name="bad_expr",
+            columns=[ColumnMapping(target="sum_col", expr='col("x"')],
+        )
+        with pytest.raises(DSLSyntaxError):
+            transform(NUMBERS_CSV, config).collect()
 
 
 # ---------------------------------------------------------------------------

--- a/whitelist_vulture.py
+++ b/whitelist_vulture.py
@@ -1,3 +1,4 @@
+BaseChatModel  # TYPE_CHECKING-only import used in string annotations
 _.delete  # unused method (src/schemashift/registry.py:31)
 _.delete  # unused method (src/schemashift/registry.py:54)
 _.delete  # unused method (src/schemashift/registry.py:92)


### PR DESCRIPTION
## Summary

- Extract `auto_transform` / `smart_transform` into dedicated `orchestration.py` module (removes circular import risk)
- Add `detection.py` with `detect_format()` — scores registered configs by specificity (`len(required) / len(file_cols)`) rather than a simple subset check
- Add `dsl/analysis.py` (`collect_col_refs`) and `dtypes.py` (`DTYPE_MAP` / `DType` Literal) as shared utilities
- Introduce `LLMBackend` protocol in `llm.py`; plain LangChain `BaseChatModel` instances are auto-wrapped via `LangChainLLMBackend`
- Add `ReviewRejectedError` to distinguish review rejections from detection failures
- Allow `constant=None` to broadcast null values; make `dt.timestamp()` unit configurable (`ms`/`us`/`ns`)
- Harden `FileSystemRegistry` against path traversal attacks
- Stream CLI `transform` output via `sink_csv`/`sink_parquet`; forward `reader_config` through generation/sampling paths
- Add `not` keyword to DSL for logical negation

## Test plan

- [ ] `rtk uv run pytest` — all tests pass
- [ ] `rtk uv run ruff check src/` — no violations
- [ ] Verify `orchestration.py` exports match previous `transform.py` surface (`auto_transform`, `smart_transform`)
- [ ] Verify `detect_format` specificity scoring via `tests/test_detection.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)