### PR TITLE
🎨 Add docs concept visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Declarative file format transformer — config-driven column mappings with a saf
 
 Transform tabular files (CSV, XLSX, Parquet, JSON, TSV) into a validated dataset using a single JSON config per source format. When encountering an unknown format, an LLM generates the config automatically.
 
+![schemashift pipeline: source file detection, registry hit or LLM-generated TransformSpec, and validated Dataset output](docs/_static/visuals/pipeline-story.svg)
+
 ## Installation
 
 ```bash

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -8,3 +8,48 @@
 .wy-nav-content {
     max-width: 1000px;
 }
+
+.schemashift-visual {
+    margin: 2rem 0;
+    overflow-x: clip;
+}
+
+.schemashift-visual img,
+.schemashift-visual svg,
+.schemashift-visual picture {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+}
+
+.schemashift-visual--hero,
+.schemashift-visual--strip {
+    max-width: 960px;
+}
+
+@media (max-width: 67em) {
+    .page,
+    .main,
+    .content,
+    .article-container,
+    article[role="main"] {
+        box-sizing: border-box;
+        min-width: 0 !important;
+        max-width: 100vw !important;
+    }
+
+    .main,
+    .content {
+        width: 100% !important;
+    }
+
+    .content {
+        padding-right: 1rem !important;
+        padding-left: 1rem !important;
+    }
+
+    .schemashift-visual {
+        margin: 1.25rem 0;
+    }
+}

--- a/docs/_static/visuals/concept-strip-mobile.svg
+++ b/docs/_static/visuals/concept-strip-mobile.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 390 520" role="img" aria-labelledby="concept-mobile-title concept-mobile-desc">
+  <title id="concept-mobile-title">schemashift core concepts</title>
+  <desc id="concept-mobile-desc">DatasetSchema is the output contract, TransformSpec is the source-to-dataset recipe, and Registry stores reusable known specs.</desc>
+  <defs>
+    <style>
+      .title{font-family:Arial,Helvetica,sans-serif;font-size:19px;font-weight:800;fill:#172033}
+      .eyebrow{font-family:Arial,Helvetica,sans-serif;font-size:12px;font-weight:800;letter-spacing:.08em;fill:#64748b}
+      .body{font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:500;fill:#475569}
+      .card{stroke-width:2}
+    </style>
+  </defs>
+  <rect x="22" y="22" width="346" height="140" rx="18" fill="#eef2ff" stroke="#3b5bdb" class="card"/>
+  <text x="50" y="62" class="eyebrow">CONTRACT</text>
+  <text x="50" y="94" class="title">DatasetSchema</text>
+  <text x="50" y="124" class="body">Column names, types, and required</text>
+  <text x="50" y="145" class="body">flags for the output.</text>
+
+  <rect x="22" y="188" width="346" height="140" rx="18" fill="#ecfdf5" stroke="#0ca678" class="card"/>
+  <text x="50" y="228" class="eyebrow">RECIPE</text>
+  <text x="50" y="260" class="title">TransformSpec</text>
+  <text x="50" y="290" class="body">Reader options and mappings for</text>
+  <text x="50" y="311" class="body">one source format.</text>
+
+  <rect x="22" y="354" width="346" height="140" rx="18" fill="#fff7ed" stroke="#f08c00" class="card"/>
+  <text x="50" y="394" class="eyebrow">REUSE</text>
+  <text x="50" y="426" class="title">Registry</text>
+  <text x="50" y="456" class="body">Known specs that detection can</text>
+  <text x="50" y="477" class="body">apply instantly.</text>
+</svg>

--- a/docs/_static/visuals/concept-strip.svg
+++ b/docs/_static/visuals/concept-strip.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 240" role="img" aria-labelledby="concept-title concept-desc">
+  <title id="concept-title">schemashift core concepts</title>
+  <desc id="concept-desc">DatasetSchema is the output contract, TransformSpec is the source-to-dataset recipe, and Registry stores reusable known specs.</desc>
+  <defs>
+    <style>
+      .title{font-family:Arial,Helvetica,sans-serif;font-size:20px;font-weight:800;fill:#172033}
+      .eyebrow{font-family:Arial,Helvetica,sans-serif;font-size:12px;font-weight:800;letter-spacing:.08em;fill:#64748b}
+      .body{font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:500;fill:#475569}
+      .card{stroke-width:2}
+    </style>
+  </defs>
+  <rect x="20" y="24" width="280" height="178" rx="18" fill="#eef2ff" stroke="#3b5bdb" class="card"/>
+  <text x="48" y="68" class="eyebrow">CONTRACT</text>
+  <text x="48" y="101" class="title">DatasetSchema</text>
+  <text x="48" y="133" class="body">Column names, types, and</text>
+  <text x="48" y="154" class="body">required flags for the output.</text>
+
+  <rect x="340" y="24" width="280" height="178" rx="18" fill="#ecfdf5" stroke="#0ca678" class="card"/>
+  <text x="368" y="68" class="eyebrow">RECIPE</text>
+  <text x="368" y="101" class="title">TransformSpec</text>
+  <text x="368" y="133" class="body">Reader options and mappings</text>
+  <text x="368" y="154" class="body">for one source format.</text>
+
+  <rect x="660" y="24" width="280" height="178" rx="18" fill="#fff7ed" stroke="#f08c00" class="card"/>
+  <text x="688" y="68" class="eyebrow">REUSE</text>
+  <text x="688" y="101" class="title">Registry</text>
+  <text x="688" y="133" class="body">Known specs that detection</text>
+  <text x="688" y="154" class="body">can apply instantly.</text>
+</svg>

--- a/docs/_static/visuals/pipeline-story-mobile.svg
+++ b/docs/_static/visuals/pipeline-story-mobile.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 390 620" role="img" aria-labelledby="pipeline-mobile-title pipeline-mobile-desc">
+  <title id="pipeline-mobile-title">schemashift mobile pipeline from source file to validated dataset</title>
+  <desc id="pipeline-mobile-desc">A source file is detected against a registry. Known formats load a TransformSpec. Unknown formats use an LLM to propose one. Both paths produce a validated Dataset.</desc>
+  <defs>
+    <marker id="mobile-arrow" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#3157d5"/>
+    </marker>
+    <marker id="mobile-miss-arrow" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#d9480f"/>
+    </marker>
+    <style>
+      .bg{fill:#fbfcff;stroke:#dbe4ff;stroke-width:2}
+      .box{stroke-width:2}
+      .label{font-family:Arial,Helvetica,sans-serif;font-size:17px;font-weight:700;fill:#172033}
+      .small{font-family:Arial,Helvetica,sans-serif;font-size:12px;font-weight:500;fill:#475569}
+      .note{font-family:Arial,Helvetica,sans-serif;font-size:12px;font-weight:700;fill:#475569}
+      .arrow{fill:none;stroke:#3157d5;stroke-width:3;marker-end:url(#mobile-arrow)}
+      .miss{fill:none;stroke:#d9480f;stroke-width:3;stroke-dasharray:8 7;marker-end:url(#mobile-miss-arrow)}
+    </style>
+  </defs>
+
+  <rect class="bg" x="14" y="16" width="362" height="588" rx="22"/>
+  <text class="label" x="38" y="54">When a tabular file arrives...</text>
+  <text class="small" x="38" y="78">Known formats reuse saved specs.</text>
+  <text class="small" x="38" y="96">Unknown formats can generate one.</text>
+
+  <rect class="box" x="62" y="126" width="266" height="66" rx="14" fill="#eef2ff" stroke="#3b5bdb"/>
+  <text class="label" x="195" y="153" text-anchor="middle">Source file</text>
+  <text class="small" x="195" y="174" text-anchor="middle">CSV / XLSX / JSON</text>
+
+  <path class="arrow" d="M195 192 V226"/>
+  <rect class="box" x="62" y="226" width="266" height="66" rx="14" fill="#fff7ed" stroke="#f08c00"/>
+  <text class="label" x="195" y="253" text-anchor="middle">Detector</text>
+  <text class="small" x="195" y="274" text-anchor="middle">column fingerprint</text>
+
+  <path class="arrow" d="M172 292 C126 314 116 344 118 368"/>
+  <rect class="box" x="34" y="368" width="154" height="72" rx="14" fill="#ecfdf5" stroke="#0ca678"/>
+  <text class="label" x="111" y="397" text-anchor="middle">Registry hit</text>
+  <text class="small" x="111" y="419" text-anchor="middle">load spec</text>
+
+  <path class="miss" d="M222 292 C270 314 282 344 282 368"/>
+  <rect class="box" x="202" y="368" width="154" height="72" rx="14" fill="#fff1f2" stroke="#e03131"/>
+  <text class="label" x="279" y="397" text-anchor="middle">Registry miss</text>
+  <text class="small" x="279" y="419" text-anchor="middle">LLM proposes</text>
+
+  <path class="arrow" d="M111 440 C118 472 145 493 178 506"/>
+  <path class="miss" d="M279 440 C270 472 243 493 212 506"/>
+  <rect class="box" x="62" y="506" width="266" height="66" rx="14" fill="#f3f0ff" stroke="#7048e8"/>
+  <text class="label" x="195" y="533" text-anchor="middle">Dataset</text>
+  <text class="small" x="195" y="554" text-anchor="middle">validated output</text>
+
+  <text class="note" x="195" y="590" text-anchor="middle">Generated TransformSpecs become reusable.</text>
+</svg>

--- a/docs/_static/visuals/pipeline-story.svg
+++ b/docs/_static/visuals/pipeline-story.svg
@@ -50,6 +50,6 @@
   <path class="arrow" d="M698 132 C739 143 756 175 766 194"/>
   <path class="miss" d="M698 280 C739 269 756 236 766 214"/>
 
-  <rect x="518" y="348" width="194" height="36" rx="18" fill="#fff" stroke="#cbd5e1"/>
-  <text class="note" x="615" y="371" text-anchor="middle">TransformSpec becomes reusable</text>
+  <text class="note" x="708" y="338">Generated TransformSpec</text>
+  <text class="note" x="708" y="356">is saved for reuse.</text>
 </svg>

--- a/docs/_static/visuals/pipeline-story.svg
+++ b/docs/_static/visuals/pipeline-story.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 440" role="img" aria-labelledby="pipeline-title pipeline-desc">
+  <title id="pipeline-title">schemashift pipeline from source file to validated dataset</title>
+  <desc id="pipeline-desc">A source file is detected against a registry. Known formats load a TransformSpec immediately. Unknown formats use an LLM to propose a TransformSpec, which can be saved for reuse. Both paths produce a validated Dataset.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#3157d5"/>
+    </marker>
+    <marker id="miss-arrow" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#d9480f"/>
+    </marker>
+    <style>
+      .bg{fill:#fbfcff;stroke:#dbe4ff;stroke-width:2}
+      .box{stroke-width:2}
+      .label{font-family:Arial,Helvetica,sans-serif;font-size:18px;font-weight:700;fill:#172033}
+      .small{font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:500;fill:#475569}
+      .note{font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:700;fill:#475569}
+      .arrow{fill:none;stroke:#3157d5;stroke-width:3;marker-end:url(#arrow)}
+      .miss{fill:none;stroke:#d9480f;stroke-width:3;stroke-dasharray:9 7;marker-end:url(#miss-arrow)}
+    </style>
+  </defs>
+
+  <rect class="bg" x="20" y="24" width="920" height="392" rx="26"/>
+  <text class="label" x="70" y="78">When a tabular file arrives...</text>
+  <text class="small" x="70" y="106">Known formats reuse a saved recipe.</text>
+  <text class="small" x="70" y="126">Unknown formats can generate one and save it for next time.</text>
+
+  <rect class="box" x="70" y="166" width="142" height="76" rx="15" fill="#eef2ff" stroke="#3b5bdb"/>
+  <text class="label" x="141" y="198" text-anchor="middle">Source file</text>
+  <text class="small" x="141" y="222" text-anchor="middle">CSV / XLSX / JSON</text>
+
+  <rect class="box" x="292" y="166" width="142" height="76" rx="15" fill="#fff7ed" stroke="#f08c00"/>
+  <text class="label" x="363" y="198" text-anchor="middle">Detector</text>
+  <text class="small" x="363" y="222" text-anchor="middle">column fingerprint</text>
+
+  <rect class="box" x="532" y="98" width="166" height="68" rx="15" fill="#ecfdf5" stroke="#0ca678"/>
+  <text class="label" x="615" y="127" text-anchor="middle">Registry hit</text>
+  <text class="small" x="615" y="149" text-anchor="middle">load TransformSpec</text>
+
+  <rect class="box" x="532" y="246" width="166" height="68" rx="15" fill="#fff1f2" stroke="#e03131"/>
+  <text class="label" x="615" y="275" text-anchor="middle">Registry miss</text>
+  <text class="small" x="615" y="297" text-anchor="middle">LLM proposes spec</text>
+
+  <rect class="box" x="766" y="166" width="142" height="76" rx="15" fill="#f3f0ff" stroke="#7048e8"/>
+  <text class="label" x="837" y="198" text-anchor="middle">Dataset</text>
+  <text class="small" x="837" y="222" text-anchor="middle">validated output</text>
+
+  <path class="arrow" d="M212 204 H292"/>
+  <path class="arrow" d="M434 193 C476 166 492 133 532 132"/>
+  <path class="miss" d="M434 216 C477 242 492 280 532 280"/>
+  <path class="arrow" d="M698 132 C739 143 756 175 766 194"/>
+  <path class="miss" d="M698 280 C739 269 756 236 766 214"/>
+
+  <rect x="518" y="348" width="194" height="36" rx="18" fill="#fff" stroke="#cbd5e1"/>
+  <text class="note" x="615" y="371" text-anchor="middle">TransformSpec becomes reusable</text>
+</svg>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,15 @@ Requires Python 3.12+.
 
 ## Core concepts
 
+```{raw} html
+<figure class="schemashift-visual schemashift-visual--strip">
+  <picture>
+    <source srcset="_static/visuals/concept-strip-mobile.svg" media="(max-width: 67em)">
+    <img src="_static/visuals/concept-strip.svg" alt="schemashift core concepts: DatasetSchema, TransformSpec, and Registry">
+  </picture>
+</figure>
+```
+
 schemashift has three objects you'll use in every pipeline:
 
 **`DatasetSchema`** — the validated dataset contract: column names, types, nullability, and optional constraints. Defined once in YAML, reused across source configs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,15 @@ When a new format arrives with no matching config, `smart_transform()` sends the
 dataset schema to your LLM, validates the generated config end-to-end, and saves it to the registry
 so the next run is instant.
 
+```{raw} html
+<figure class="schemashift-visual schemashift-visual--hero">
+  <picture>
+    <source srcset="_static/visuals/pipeline-story-mobile.svg" media="(max-width: 67em)">
+    <img src="_static/visuals/pipeline-story.svg" alt="schemashift pipeline: source file detection, registry hit or LLM-generated TransformSpec, and validated Dataset output">
+  </picture>
+</figure>
+```
+
 ---
 
 ## Thirty-second example


### PR DESCRIPTION
## Summary

- Add editable SVG Pipeline Story visuals for README and the docs homepage.
- Add desktop and stacked mobile variants to avoid narrow-width overflow.
- Add a compact `DatasetSchema` / `TransformSpec` / `Registry` concept strip for Getting Started.

Stacked on #9 because these visuals use the ontology-cleanup terminology.

## Test Plan

- [x] `rtk uv run --extra docs sphinx-build -b html docs docs/_build/html`
- [x] `/opt/homebrew/bin/rg -n "TargetSchema|SchemaConfig|target_schema|target schema" README.md docs/index.md docs/getting-started.md docs/_static/visuals`
- [x] `rtk uv run python` XML parse check for all `docs/_static/visuals/*.svg`
- [x] `rtk uv run --extra dev ruff check src tests`
- [x] `rtk uv run --extra dev black --check src tests`
- [x] Quick Look thumbnail renders for desktop and mobile SVG variants
